### PR TITLE
Add command for transferring liked tracks 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Setup
 For backwards compatibility you can also create your own file and pass it using ``--file settings.ini``.
 
 If you want to transfer private playlists from Spotify (i.e. liked songs), choose "yes" for oAuth authentication, otherwise choose "no".
-For oAuth authentication you should set `http://localhost` as redirect URI for your app in Spotify's developer dashboard.
+For oAuth authentication you should set ``http://localhost`` as redirect URI for your app in Spotify's developer dashboard.
 
 Usage
 ------
@@ -80,13 +80,13 @@ For migration purposes, it is possible to transfer all public playlists of a use
 Transfer liked tracks of the Spotify user
 -----------------------------------------
 
-**You must you oAuth authentification for transfering liked songs.**
+**You must you oAuth authentication for transferring liked songs.**
 
 .. code-block::
 
    spotify_to_ytmusic liked
 
-This command will open browser where you should give access to your account (if you havn't done that before). 
+This command will open browser where you should give access to your account (if you haven't done that before).
 After authorization you will be redirected to localhost, copy link you were redirected to (looks like localhost/?code=...) and paste to command line.
 
 Command line options

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,8 @@ Setup
 
 For backwards compatibility you can also create your own file and pass it using ``--file settings.ini``.
 
-If you want to transfer liked songs from Spotify, choose "yes" for oAuth authentification, otherwise choose "no".
+If you want to transfer private playlists from Spotify (i.e. liked songs), choose "yes" for oAuth authentication, otherwise choose "no".
+For oAuth authentication you should set `http://localhost` as redirect URI for your app in Spotify's developer dashboard.
 
 Usage
 ------

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,8 @@ Setup
 
 For backwards compatibility you can also create your own file and pass it using ``--file settings.ini``.
 
+If you want to transfer liked songs from Spotify, choose "yes" for oAuth authentification, otherwise choose "no".
+
 Usage
 ------
 
@@ -73,6 +75,18 @@ For migration purposes, it is possible to transfer all public playlists of a use
 .. code-block::
 
     spotify_to_ytmusic all <spotifyuserid>
+
+Transfer liked tracks of the Spotify user
+-----------------------------------------
+
+**You must you oAuth authentification for transfering liked songs.**
+
+.. code-block::
+
+   spotify_to_ytmusic liked
+
+This command will open browser where you should give access to your account (if you havn't done that before). 
+After authorization you will be redirected to localhost, copy link you were redirected to (looks like localhost/?code=...) and paste to command line.
 
 Command line options
 ---------------------

--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -47,7 +47,7 @@ def liked(args):
     if len(tracks) == 0:
         exit("Could not find any liked tracks for the user.")
 
-    print(str(len(tracks)) + " tracks found. Creating playlist...")
+    print(f"{len(tracks)} tracks found. Creating playlist...")
     try:
         videos_ids = ytmusic.search_songs(tracks)
         playlist_id = ytmusic.create_playlist(

--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -41,6 +41,25 @@ def all(args):
         except Exception as ex:
             print(f"Could not transfer playlist {p['name']}. {str(ex)}")
 
+def liked(args):
+    spotify, ytmusic = _init()
+    tracks = spotify.getLikedTracks()
+    if len(tracks) == 0:
+        exit("Could not find any liked tracks for the user.")
+
+    print(str(len(tracks)) + " tracks found. Creating playlist...")
+    try:
+        videos_ids = ytmusic.search_songs(tracks)
+        playlist_id = ytmusic.create_playlist(
+            "Liked songs (Spotify)",
+            "your liked tracks from spotify",
+            "PRIVATE",
+            videos_ids,
+        )
+        print(playlist_id)
+    except Exception as ex:
+        print("Could not transfer liked songs. " + str(ex))
+
 
 def create(args):
     spotify, ytmusic = _init()

--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -15,36 +15,43 @@ def get_args(args=None):
     spotify_playlist = argparse.ArgumentParser(add_help=False)
     spotify_playlist.add_argument("playlist", type=str, help="Provide a playlist Spotify link.")
 
-    create_parser = subparsers.add_parser(
-        "create",
-        help="Create a new playlist on YouTube Music.",
-        parents=[spotify_playlist],
-    )
-    create_parser.set_defaults(func=controllers.create)
-    create_parser.add_argument(
+    spotify_playlist_create = argparse.ArgumentParser(add_help=False)
+    spotify_playlist_create.add_argument(
         "-d",
         "--date",
         action="store_true",
         help="Append the current date to the playlist name",
     )
-    create_parser.add_argument(
+    spotify_playlist_create.add_argument(
         "-i",
         "--info",
         type=str,
         help="Provide description information for the YouTube Music Playlist. Default: Spotify playlist description",
     )
-    create_parser.add_argument(
+    spotify_playlist_create.add_argument(
         "-n",
         "--name",
         type=str,
         help="Provide a name for the YouTube Music playlist. Default: Spotify playlist name",
     )
-    create_parser.add_argument(
+    spotify_playlist_create.add_argument(
         "-p",
         "--public",
         action="store_true",
         help="Make created playlist public. Default: private",
     )
+
+    create_parser = subparsers.add_parser(
+        "create",
+        help="Create a new playlist on YouTube Music.",
+        parents=[spotify_playlist, spotify_playlist_create],
+    )
+    create_parser.set_defaults(func=controllers.create)
+
+    liked_parser = subparsers.add_parser(
+        "liked", help="Transfer all liked songs of the user.", parents=[spotify_playlist_create]
+    )
+    liked_parser.set_defaults(func=controllers.liked)
 
     update_parser = subparsers.add_parser(
         "update",
@@ -70,11 +77,6 @@ def get_args(args=None):
     )
     all_parser.add_argument("user", type=str, help="Spotify userid of the specified user.")
     all_parser.set_defaults(func=controllers.all)
-
-    liked_parser = subparsers.add_parser(
-        "liked", help="Transfer all liked songs of the user."
-    )
-    liked_parser.set_defaults(func=controllers.liked)
 
     return parser.parse_args(args)
 

--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -71,6 +71,11 @@ def get_args(args=None):
     all_parser.add_argument("user", type=str, help="Spotify userid of the specified user.")
     all_parser.set_defaults(func=controllers.all)
 
+    liked_parser = subparsers.add_parser(
+        "liked", help="Transfer all liked songs of the user."
+    )
+    liked_parser.set_defaults(func=controllers.liked)
+
     return parser.parse_args(args)
 
 

--- a/spotify_to_ytmusic/settings.ini.example
+++ b/spotify_to_ytmusic/settings.ini.example
@@ -5,3 +5,4 @@ user_id =
 [spotify]
 client_id = id_from_developer_console
 client_secret = secret_from_developer_console
+use_oauth = no

--- a/spotify_to_ytmusic/setup.py
+++ b/spotify_to_ytmusic/setup.py
@@ -43,6 +43,7 @@ def setup_spotify():
             "Paste your client id from the Spotify developer dashboard:"
         ),
         "client_secret": input("Paste your client secret from the Spotify developer dashboard:"),
+        "use_oauth": input("Use OAuth method for authorization (required for transfer liked songs) yes/no:"),
     }
     settings["spotify"].update(credentials)
     settings.save()

--- a/spotify_to_ytmusic/setup.py
+++ b/spotify_to_ytmusic/setup.py
@@ -39,11 +39,11 @@ def setup_youtube():
 def setup_spotify():
     settings = Settings()
     credentials = {
-        "client_id": input(
-            "Paste your client id from the Spotify developer dashboard:"
-        ),
+        "client_id": input("Paste your client id from the Spotify developer dashboard:"),
         "client_secret": input("Paste your client secret from the Spotify developer dashboard:"),
-        "use_oauth": input("Use OAuth method for authorization (required for transfer liked songs) yes/no:"),
+        "use_oauth": input(
+            "Use OAuth method for authorization to transfer private playlists (yes/no):"
+        ),
     }
     settings["spotify"].update(credentials)
     settings.save()

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
+from spotipy.oauth2 import SpotifyOAuth
 
 from spotify_to_ytmusic.settings import Settings
 
@@ -22,10 +23,15 @@ class Spotify:
             string.hexdigits
         ), f"Spotify client_secret not set or invalid: {client_secret}"
 
-        client_credentials_manager = SpotifyClientCredentials(
-            client_id=client_id, client_secret=client_secret
-        )
-        self.api = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
+        use_oauth = conf["use_oauth"] == "y" or conf["use_oauth"] == "yes"
+        if use_oauth:
+            auth = SpotifyOAuth(client_id=client_id, client_secret=client_secret, redirect_uri="http://localhost", scope="user-library-read")
+            self.api = spotipy.Spotify(auth_manager=auth)
+        else:
+            client_credentials_manager = SpotifyClientCredentials(
+                client_id=client_id, client_secret=client_secret
+            )
+            self.api = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
 
     def getSpotifyPlaylist(self, url):
         playlistId = get_id_from_url(url)

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -70,6 +70,15 @@ class Spotify:
 
         return [p for p in pl if p["owner"]["id"] == user and p["tracks"]["total"] > 0]
 
+    def getLikedTracks(self):
+        response = self.api.current_user_saved_tracks(limit=50)
+        tracks = response["items"]
+        while response["next"] != None:
+            response = self.api.current_user_saved_tracks(limit=50, offset=response["offset"] + 50)
+            tracks.extend(response["items"])
+
+        return build_results(tracks)
+
 
 def build_results(tracks, album=None):
     results = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,12 +23,19 @@ class TestCli(unittest.TestCase):
         args = get_args(["setup"])
         self.assertEqual(len(vars(args)), 3)
 
+    def test_liked(self):
+        with mock.patch(
+            "sys.argv", ["", "liked", "-n", "spotify_to_ytmusic", "-d", "-i", "test liked"]
+        ):
+            main()
+
     def test_create(self):
         with mock.patch("sys.argv", ["", "all", "sigmatics"]):
             main()
 
         with mock.patch(
-            "sys.argv", ["", "create", TEST_PLAYLIST, "-n", "spotify_to_ytmusic", "-i", "test-playlist", "-d"]
+            "sys.argv",
+            ["", "create", TEST_PLAYLIST, "-n", "spotify_to_ytmusic", "-i", "test-playlist", "-d"],
         ):
             main()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,7 @@ class TestCli(unittest.TestCase):
         example_path = Settings.filepath.parent.joinpath("settings.ini.example")
         shutil.copy(example_path, tmp_path)
         with mock.patch("sys.argv", ["", "setup"]), mock.patch(
-            "builtins.input", return_value="3"
+            "builtins.input", side_effect=["3", "a", "b", "yes", ""]
         ), mock.patch(
             "ytmusicapi.auth.oauth.YTMusicOAuth.get_token_from_code",
             return_value=json.loads(Settings()["youtube"]["headers"]),
@@ -65,8 +65,8 @@ class TestCli(unittest.TestCase):
             main()
             assert tmp_path.is_file()
             settings = Settings()
-            assert settings["spotify"]["client_id"] == "3"
-            assert settings["spotify"]["client_secret"] == "3"
+            assert settings["spotify"]["client_id"] == "a"
+            assert settings["spotify"]["client_secret"] == "b"
             tmp_path.unlink()
 
         with mock.patch("sys.argv", ["", "setup", "--file", example_path.as_posix()]), mock.patch(

--- a/tests/test_spotipy.py
+++ b/tests/test_spotipy.py
@@ -4,12 +4,13 @@ from spotify_to_ytmusic.spotify import Spotify
 
 
 class TestSpotify(unittest.TestCase):
-
     def setUp(self) -> None:
         self.spotify = Spotify()
 
     def test_getSpotifyPlaylist(self):
-        data = self.spotify.getSpotifyPlaylist("https://open.spotify.com/playlist/03ICMYsVsC4I2SZnERcQJb")
+        data = self.spotify.getSpotifyPlaylist(
+            "https://open.spotify.com/playlist/03ICMYsVsC4I2SZnERcQJb"
+        )
         self.assertEqual(len(data), 3)
         self.assertGreater(len(data["tracks"]), 190)
 


### PR DESCRIPTION
This PR adds implementation for transfer liked songs from Spotify to YM. It adds oAuth authentification method optionally and creates new command. Implementation follows ideas described in issue #27 