### PR TITLE
fix: parse Spotify playlist ids from playlists with a share id query parameter correctly

### DIFF
--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -42,9 +42,7 @@ class Spotify:
             self.api = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
 
     def getSpotifyPlaylist(self, url):
-        playlistId = get_id_from_url(url)
-        if len(playlistId) != 22:
-            raise Exception(f"Bad playlist id: {playlistId}")
+        playlistId = self.getPlaylistIdFromUrl(url)
 
         print("Getting Spotify tracks...")
         results = self.api.playlist(playlistId)
@@ -91,6 +89,16 @@ class Spotify:
             "description": "Your liked tracks from spotify",
         }
 
+    __id_extraction_regex = re.compile(r"playlist\/(?P<id>\w{22})\W?")
+
+    @classmethod
+    def getPlaylistIdFromUrl(cls, url) -> str:
+        if (match := cls.__id_extraction_regex.search(url)):
+            return match.group("id")
+        elif (match := re.search(r"playlist\/(?P<id>\w+)\W?", url)):
+            raise ValueError(f"Bad playlist id: {id}")
+        else:
+            raise ValueError(f"No id found in playlist url: {url}")
 
 def build_results(tracks, album=None):
     results = []
@@ -110,12 +118,3 @@ def build_results(tracks, album=None):
         )
 
     return results
-
-
-_id_extraction_regex = re.compile(r"playlist\/(?P<id>\w{22})\W")
-
-
-def get_id_from_url(url):
-    url_parts = parse_url(url)
-    matches = re.search(url)
-    return matches.group("id)

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -42,7 +42,7 @@ class Spotify:
             self.api = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
 
     def getSpotifyPlaylist(self, url):
-        playlistId = self.getPlaylistIdFromUrl(url)
+        playlistId = extract_playlist_id_from_url(url)
 
         print("Getting Spotify tracks...")
         results = self.api.playlist(playlistId)
@@ -89,17 +89,6 @@ class Spotify:
             "description": "Your liked tracks from spotify",
         }
 
-    __id_extraction_regex = re.compile(r"playlist\/(?P<id>\w{22})\W?")
-
-    @classmethod
-    def getPlaylistIdFromUrl(cls, url) -> str:
-        if (match := cls.__id_extraction_regex.search(url)):
-            return match.group("id")
-        elif (match := re.search(r"playlist\/(?P<id>\w+)\W?", url)):
-            raise ValueError(f"Bad playlist id: {id}")
-        else:
-            raise ValueError(f"No id found in playlist url: {url}")
-
 def build_results(tracks, album=None):
     results = []
     for track in tracks:
@@ -118,3 +107,13 @@ def build_results(tracks, album=None):
         )
 
     return results
+
+
+def extract_playlist_id_from_url(url: str) -> str:
+    if (match := re.search(r"playlist\/(?P<id>\w{22})\W?", url)):
+        return match.group("id")
+    elif (match := re.search(r"playlist\/(?P<id>\w+)\W?", url)):
+        id = match.group("id")
+        raise ValueError(f"Bad playlist id: {id}\nA playlist id should be 22 characters long, not {len(id)}")
+    else:
+        raise ValueError(f"Couldn't understand playlist url: {url}\nA playlist url should look like this: https://open.spotify.com/playlist/37i9dQZF1DZ06evO41HwPk")

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -1,6 +1,6 @@
 import html
 import string
-from urllib.parse import urlparse
+import re
 
 import spotipy
 from spotipy import CacheFileHandler
@@ -112,10 +112,10 @@ def build_results(tracks, album=None):
     return results
 
 
+_id_extraction_regex = re.compile(r"playlist\/(?P<id>\w{22})\W")
+
+
 def get_id_from_url(url):
     url_parts = parse_url(url)
-    return url_parts.path.split("/")[2]
-
-
-def parse_url(url):
-    return urlparse(url)
+    matches = re.search(url)
+    return matches.group("id)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,21 +1,21 @@
 import unittest
 
-from spotify_to_ytmusic.spotify import Spotify
+from spotify_to_ytmusic.spotify import extract_playlist_id_from_url
 
 
 class TestParsing(unittest.TestCase):
     def test_idFromSpotifyUrl(self):
         url = "https://open.spotify.com/playlist/37i9dQZF1DX5KpP2LN299J"
-        self.assertEqual(Spotify.getPlaylistIdFromUrl(url), "37i9dQZF1DX5KpP2LN299J")
+        self.assertEqual(extract_playlist_id_from_url(url), "37i9dQZF1DX5KpP2LN299J")
 
     def test_idFromSpotifyUrlWithShareId(self):
         url = "http://open.spotify.com/playlist/37i9dQZF1DZ06evO3siF1W?si=grips"
-        self.assertEqual(Spotify.getPlaylistIdFromUrl(url), "37i9dQZF1DZ06evO3siF1W")
+        self.assertEqual(extract_playlist_id_from_url(url), "37i9dQZF1DZ06evO3siF1W")
 
     def test_idFromSpotifyUrlRejectBadId(self):
         url = "https://open.spotify.com/playlist/420"
-        self.assertRaises(ValueError, Spotify.getPlaylistIdFromUrl, url)
+        self.assertRaisesRegex(ValueError, r"Bad playlist id", extract_playlist_id_from_url, url)
     
     def test_idFromSpotifyUrlRejectBadUrl(self):
         url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-        self.assertRaises(ValueError, Spotify.getPlaylistIdFromUrl, url)
+        self.assertRaises(ValueError, extract_playlist_id_from_url, url)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,21 @@
+import unittest
+
+from spotify_to_ytmusic.spotify import Spotify
+
+
+class TestParsing(unittest.TestCase):
+    def test_idFromSpotifyUrl(self):
+        url = "https://open.spotify.com/playlist/37i9dQZF1DX5KpP2LN299J"
+        self.assertEqual(Spotify.getPlaylistIdFromUrl(url), "37i9dQZF1DX5KpP2LN299J")
+
+    def test_idFromSpotifyUrlWithShareId(self):
+        url = "http://open.spotify.com/playlist/37i9dQZF1DZ06evO3siF1W?si=grips"
+        self.assertEqual(Spotify.getPlaylistIdFromUrl(url), "37i9dQZF1DZ06evO3siF1W")
+
+    def test_idFromSpotifyUrlRejectBadId(self):
+        url = "https://open.spotify.com/playlist/420"
+        self.assertRaises(ValueError, Spotify.getPlaylistIdFromUrl, url)
+    
+    def test_idFromSpotifyUrlRejectBadUrl(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        self.assertRaises(ValueError, Spotify.getPlaylistIdFromUrl, url)


### PR DESCRIPTION
Such as [https://open.spotify.com/playlist/37i9dQZF1DX5KpP2LN299J?si=asdf](open.spotify.com/playlist/37i9dQZF1DX5KpP2LN299J?si=asdf)
