### PR TITLE
update all playlists

### DIFF
--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -76,6 +76,7 @@ def get_args(args=None):
         "all", help="Transfer all public playlists of the specified user (Spotify User ID)."
     )
     all_parser.add_argument("user", type=str, help="Spotify userid of the specified user.")
+    all_parser.add_argument("--update", type=str, help="Update playlist with the same names instead of creating duplicate ones. Specify methodo (delete or append)")
     all_parser.set_defaults(func=controllers.all)
 
     return parser.parse_args(args)


### PR DESCRIPTION
add `--update` flag to `all` command.

what it does: runs the traditional `all` command, but all your ytmusic playlists that have the same name from spotify are updated instead of creating new ones. After the `--update` flag it is necessary to inform the update method (append or delete), for example:

`spotify_to_ytmusic all <youruserid> --update append`

Now you can schedule a cronjob on your server to have your YouTube music always up to date (✿◠‿◠)