### PR TITLE
Opt-in caching to speed up search of redundant tracks

### DIFF
--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -40,7 +40,9 @@ def all(args):
         count = count + 1
         try:
             playlist = spotify.getSpotifyPlaylist(p["external_urls"]["spotify"])
-            videoIds = ytmusic.search_songs(playlist["tracks"], use_cached=args.use_cached)
+            videoIds = ytmusic.search_songs(
+                playlist["tracks"], use_cached=args.use_cached
+            )
             playlist_id = ytmusic.create_playlist(
                 p["name"],
                 p["description"],
@@ -101,6 +103,7 @@ def remove(args):
     ytmusic = YTMusicTransfer()
     ytmusic.remove_playlists(args.pattern)
 
+
 def search(args):
     spotify, ytmusic = _init()
     track = spotify.getSingleTrack(args.link)
@@ -108,7 +111,7 @@ def search(args):
         "name": track["name"],
         "artist": track["artists"][0]["name"],
         "duration": track["duration_ms"] / 1000,
-        "album": track['album']['name']
+        "album": track["album"]["name"],
     }
 
     video_id = ytmusic.search_songs([tracks], use_cached=args.use_cached)
@@ -117,11 +120,14 @@ def search(args):
         print("Error: No Match found.")
         return
     print(f"https://music.youtube.com/watch?v={video_id[0]}")
-    
+
+
 def cache_clear(args):
     from spotify_to_ytmusic.utils.cache_manager import CacheManager
+
     cacheManager = CacheManager()
     cacheManager.remove_cache_file()
+
 
 def setup(args):
     setup_func(args.file)

--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -1,4 +1,3 @@
-import os
 import time
 from datetime import datetime
 

--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -111,12 +111,18 @@ def search(args):
         "duration": track["duration_ms"] / 1000,
         "album": track['album']['name']
     }
-    video_id = ytmusic.search_songs([tracks], use_cached=args.use_cached)
-    print(f"https://music.youtube.com/watch?v={video_id[0]}")   
 
-def cache_clear(args):
-    path = os.path.dirname(os.path.realpath(__file__)) + os.sep
-    os.remove(path + "lookup.json")
+    video_id = ytmusic.search_songs([tracks], use_cached=args.use_cached)
+
+    if not video_id:
+        print("Error: No Match found.")
+        return
+    print(f"https://music.youtube.com/watch?v={video_id[0]}")
     
+def cache_clear(args):
+    from spotify_to_ytmusic.utils.cache_manager import CacheManager
+    cacheManager = CacheManager()
+    cacheManager.remove_cache_file()
+
 def setup(args):
     setup_func(args.file)

--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -35,6 +35,14 @@ def get_args(args=None):
         "--file", type=Path, help="Optional path to a settings.ini file"
     )
 
+    cache_parser = argparse.ArgumentParser(add_help=False)
+    cache_parser.add_argument(
+        '--use-cached',
+        action="store_true",
+        default=False,
+        help="(Optional) Enable the use of a cache file to save and retrieve query results."
+    )
+
     spotify_playlist = argparse.ArgumentParser(add_help=False)
     spotify_playlist.add_argument(
         "playlist", type=str, help="Provide a playlist Spotify link."
@@ -75,14 +83,14 @@ def get_args(args=None):
     create_parser = subparsers.add_parser(
         "create",
         help="Create a new playlist on YouTube Music.",
-        parents=[spotify_playlist, spotify_playlist_create],
+        parents=[spotify_playlist, spotify_playlist_create, cache_parser],
     )
     create_parser.set_defaults(func=controllers.create)
 
     liked_parser = subparsers.add_parser(
         "liked",
         help="Transfer all liked songs of the user.",
-        parents=[spotify_playlist_create],
+        parents=[spotify_playlist_create, cache_parser],
     )
     liked_parser.set_defaults(func=controllers.liked)
 
@@ -90,7 +98,7 @@ def get_args(args=None):
         "update",
         help="Delete all entries in the provided Google Play Music playlist and "
         "update the playlist with entries from the Spotify playlist.",
-        parents=[spotify_playlist],
+        parents=[spotify_playlist, cache_parser],
     )
     update_parser.set_defaults(func=controllers.update)
     update_parser.add_argument(
@@ -109,6 +117,7 @@ def get_args(args=None):
     all_parser = subparsers.add_parser(
         "all",
         help="Transfer all public playlists of the specified user (Spotify User ID).",
+        parents=[cache_parser],
     )
     all_parser.add_argument(
         "user", type=str, help="Spotify userid of the specified user."
@@ -120,6 +129,16 @@ def get_args(args=None):
         action="store_true",
         help="Like the songs in all of the public playlist",
     )
+
+    search_parser = subparsers.add_parser(
+        "search", help="Search for a song in yt music (Algorthm Testing).",
+        parents=[cache_parser]
+    )
+    search_parser.add_argument("link", type=str, help="Link of the spotify song to search.")
+    search_parser.set_defaults(func=controllers.search)
+
+    cache_remove_parser = subparsers.add_parser("cache-clear", help="Clear cache file")
+    cache_remove_parser.set_defaults(func=controllers.cache_clear)
 
     return parser.parse_args(args)
 

--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -131,7 +131,7 @@ def get_args(args=None):
     )
 
     search_parser = subparsers.add_parser(
-        "search", help="Search for a song in yt music (Algorthm Testing).",
+        "search", help="Search for a song on YouTube Music to cross-check the algorithm match result.",
         parents=[cache_parser]
     )
     search_parser.add_argument("link", type=str, help="Link of the spotify song to search.")

--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -37,10 +37,10 @@ def get_args(args=None):
 
     cache_parser = argparse.ArgumentParser(add_help=False)
     cache_parser.add_argument(
-        '--use-cached',
+        "--use-cached",
         action="store_true",
         default=False,
-        help="(Optional) Enable the use of a cache file to save and retrieve query results."
+        help="(Optional) Enable the use of a cache file to save and retrieve query results.",
     )
 
     spotify_playlist = argparse.ArgumentParser(add_help=False)
@@ -131,10 +131,13 @@ def get_args(args=None):
     )
 
     search_parser = subparsers.add_parser(
-        "search", help="Search for a song on YouTube Music to cross-check the algorithm match result.",
-        parents=[cache_parser]
+        "search",
+        help="Search for a song on YouTube Music to cross-check the algorithm match result.",
+        parents=[cache_parser],
     )
-    search_parser.add_argument("link", type=str, help="Link of the spotify song to search.")
+    search_parser.add_argument(
+        "link", type=str, help="Link of the spotify song to search."
+    )
     search_parser.set_defaults(func=controllers.search)
 
     cache_remove_parser = subparsers.add_parser("cache-clear", help="Clear cache file")

--- a/spotify_to_ytmusic/setup.py
+++ b/spotify_to_ytmusic/setup.py
@@ -83,7 +83,6 @@ def setup_spotify():
         ),
         "client_secret": input(
             "Paste your client secret from the Spotify developer dashboard:"
-
         ),
         "use_oauth": str(
             query_yes_no(

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -98,7 +98,9 @@ class Spotify:
             "name": "Liked songs (Spotify)",
             "description": "Your liked tracks from spotify",
         }
-
+    
+    def getSingleTrack(self, song_url):
+        return self.api.track(song_url)
 
 def build_results(tracks, album=None):
     results = []

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -98,9 +98,10 @@ class Spotify:
             "name": "Liked songs (Spotify)",
             "description": "Your liked tracks from spotify",
         }
-    
+
     def getSingleTrack(self, song_url):
         return self.api.track(song_url)
+
 
 def build_results(tracks, album=None):
     results = []

--- a/spotify_to_ytmusic/utils/cache_manager.py
+++ b/spotify_to_ytmusic/utils/cache_manager.py
@@ -1,6 +1,7 @@
 import json
 from spotify_to_ytmusic.settings import CACHE_DIR
 
+
 class CacheManager:
     def __init__(self):
         self.cache_dir = CACHE_DIR
@@ -17,7 +18,7 @@ class CacheManager:
     def save_to_lookup_table(self, table):
         with self.cache_file.open("w", encoding="utf-8") as f:
             json.dump(table, f, ensure_ascii=False)
-    
+
     def remove_cache_file(self):
         if self.cache_file.is_file():
             self.cache_file.unlink()

--- a/spotify_to_ytmusic/utils/cache_manager.py
+++ b/spotify_to_ytmusic/utils/cache_manager.py
@@ -1,6 +1,4 @@
 import json
-import os
-from pathlib import Path
 from spotify_to_ytmusic.settings import CACHE_DIR
 
 class CacheManager:

--- a/spotify_to_ytmusic/utils/cache_manager.py
+++ b/spotify_to_ytmusic/utils/cache_manager.py
@@ -1,0 +1,25 @@
+import json
+import os
+from pathlib import Path
+from spotify_to_ytmusic.settings import CACHE_DIR
+
+class CacheManager:
+    def __init__(self):
+        self.cache_dir = CACHE_DIR
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_file = self.cache_dir / "lookup.json"
+
+    def load_lookup_table(self):
+        try:
+            with self.cache_file.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return {}
+
+    def save_to_lookup_table(self, table):
+        with self.cache_file.open("w", encoding="utf-8") as f:
+            json.dump(table, f, ensure_ascii=False)
+    
+    def remove_cache_file(self):
+        if self.cache_file.is_file():
+            self.cache_file.unlink()

--- a/spotify_to_ytmusic/ytmusic.py
+++ b/spotify_to_ytmusic/ytmusic.py
@@ -1,6 +1,4 @@
-import json
 import os
-from pathlib import Path
 import re
 from collections import OrderedDict
 

--- a/spotify_to_ytmusic/ytmusic.py
+++ b/spotify_to_ytmusic/ytmusic.py
@@ -14,6 +14,7 @@ path = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 cacheManager = CacheManager()
 
+
 class YTMusicTransfer:
     def __init__(self):
         settings = Settings()
@@ -42,10 +43,10 @@ class YTMusicTransfer:
         songs = list(tracks)
         notFound = list()
         lookup_ids = cacheManager.load_lookup_table()
-        
+
         if use_cached:
             print("Use of cache file is enabled.")
-        
+
         print("Searching YouTube...")
         for i, song in enumerate(songs):
             name = re.sub(r" \(feat.*\..+\)", "", song["name"])

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,0 +1,48 @@
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+from platformdirs import user_cache_dir
+from spotify_to_ytmusic.utils.cache_manager import CacheManager
+
+class TestCacheManager(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cache_manager = CacheManager()
+        cls.test_data = {
+            "Jordan Burns Weekend": "4ga4xy7omAE",
+            "Robert DeLong Lights LŪN Did It To Myself - LŪN Remix": "M7jON1NmyoY",
+        }
+    
+    def setUp(self):
+        self.cache_manager.remove_cache_file()
+
+    def test_save_and_load_lookup_table(self):
+        """Test that data is correctly saved and loaded from cache."""
+        self.cache_manager.save_to_lookup_table(self.test_data)
+        
+        loaded_data = self.cache_manager.load_lookup_table()
+        self.assertEqual(loaded_data, self.test_data)
+
+    def test_load_empty_lookup_table(self):
+        """Test that loading a non-existing cache returns an empty dictionary."""
+        self.assertEqual(self.cache_manager.load_lookup_table(), {})
+
+    def test_remove_cache_file(self):
+        """Test that the cache file is properly deleted."""
+        self.cache_manager.save_to_lookup_table(self.test_data)
+
+        self.assertTrue(self.cache_manager.cache_file.exists())
+
+        self.cache_manager.remove_cache_file()
+        self.assertFalse(self.cache_manager.cache_file.exists())
+
+    def test_cache_file_location(self):
+        """Test that the cache file is created in the correct platformdirs location."""
+        expected_path = Path(user_cache_dir(appname="spotify_to_ytmusic", appauthor=False)) / "lookup.json"
+        self.assertEqual(self.cache_manager.cache_file, expected_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from platformdirs import user_cache_dir
 from spotify_to_ytmusic.utils.cache_manager import CacheManager
 
-class TestCacheManager(unittest.TestCase):
 
+class TestCacheManager(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cache_manager = CacheManager()
@@ -12,14 +12,14 @@ class TestCacheManager(unittest.TestCase):
             "Jordan Burns Weekend": "4ga4xy7omAE",
             "Robert DeLong Lights LŪN Did It To Myself - LŪN Remix": "M7jON1NmyoY",
         }
-    
+
     def setUp(self):
         self.cache_manager.remove_cache_file()
 
     def test_save_and_load_lookup_table(self):
         """Test that data is correctly saved and loaded from cache."""
         self.cache_manager.save_to_lookup_table(self.test_data)
-        
+
         loaded_data = self.cache_manager.load_lookup_table()
         self.assertEqual(loaded_data, self.test_data)
 
@@ -38,7 +38,10 @@ class TestCacheManager(unittest.TestCase):
 
     def test_cache_file_location(self):
         """Test that the cache file is created in the correct platformdirs location."""
-        expected_path = Path(user_cache_dir(appname="spotify_to_ytmusic", appauthor=False)) / "lookup.json"
+        expected_path = (
+            Path(user_cache_dir(appname="spotify_to_ytmusic", appauthor=False))
+            / "lookup.json"
+        )
         self.assertEqual(self.cache_manager.cache_file, expected_path)
 
 

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,7 +1,5 @@
-import json
 import unittest
 from pathlib import Path
-from unittest import mock
 from platformdirs import user_cache_dir
 from spotify_to_ytmusic.utils.cache_manager import CacheManager
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from spotify_to_ytmusic.settings import DEFAULT_PATH, EXAMPLE_PATH, CACHE_DIR, S
 TEST_PLAYLIST = "https://open.spotify.com/playlist/4UzyZJfSQ4584FaWGwepfL"
 TEST_SONG = "https://open.spotify.com/track/7bnczC5ATlZaZX0MHjX7KU?si=5a07bffaf6324717"
 
+
 class TestCli(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -74,22 +75,21 @@ class TestCli(unittest.TestCase):
                 int(fakeOutput.getvalue().splitlines()[-1][0]) >= 2
             )  # assert number of lines deleted
 
-
     def test_search(self):
-        with mock.patch("sys.argv", ['', 'search', TEST_SONG]):
+        with mock.patch("sys.argv", ["", "search", TEST_SONG]):
             main()
-    
+
     def test_search_with_use_cached_flag(self):
         cache_file = CACHE_DIR / "lookup.json"
-        
+
         # Ensure the cache file doesn't exist before running the test
         if cache_file.exists():
             cache_file.unlink()
 
-        with mock.patch("sys.argv", ['', 'search', TEST_SONG, '--use-cached']):
+        with mock.patch("sys.argv", ["", "search", TEST_SONG, "--use-cached"]):
             main()
         self.assertTrue(cache_file.exists(), "Cache file was not created.")
-    
+
     def test_setup(self):
         tmp_path = DEFAULT_PATH.with_suffix(".tmp")
         settings = Settings()


### PR DESCRIPTION
- `--use-cached` is opt-in flag to stores the result of search in `lookup.json` file. Can be used with `create`, `liked`, `update` and `all` argument.
- `cache-clear` argument clears the cache file.
- `search` argument is just for testing what algorithm returns (and trust me YouTube doesn't always give the results correctly every time).