### PR TITLE
Update liked playlist from spotify + Request time-out fix when updating playlist + Append mode now handles duplicate errors

### DIFF
--- a/spotify_to_ytmusic/main.py
+++ b/spotify_to_ytmusic/main.py
@@ -102,10 +102,19 @@ def get_args(args=None):
     )
     update_parser.set_defaults(func=controllers.update)
     update_parser.add_argument(
-        "name", type=str, help="The name of the YouTube Music playlist to update."
+        "name",
+        type=str,
+        help='The name of the YouTube Music playlist to update. Use "liked" to sync Spotify liked songs to the target YouTube Music playlist.',
     )
     update_parser.add_argument(
-        "--append", help="Do not delete items, append to target playlist instead"
+        "--append",
+        help="Do not delete items, append to target playlist instead",
+        action="store_true",
+    )
+    update_parser.add_argument(
+        "--remove-extra",
+        help="Remove tracks from the target playlist that are not in the Spotify playlist (only works with --append).",
+        action="store_true",
     )
 
     remove_parser = subparsers.add_parser(

--- a/spotify_to_ytmusic/ytmusic.py
+++ b/spotify_to_ytmusic/ytmusic.py
@@ -93,6 +93,23 @@ class YTMusicTransfer:
         except StopIteration:
             raise Exception("Playlist title not found in playlists")
 
+    def get_playlist_videoIds(self, playlistId):
+        items = self.api.get_playlist(playlistId, 10000)
+        if "tracks" in items and items["tracks"]:
+            return [x["videoId"] for x in items["tracks"]]
+        return []
+
+    def remove_specified_tracks(self, playlistId, tracks):
+        items = self.api.get_playlist(playlistId, 10000)
+
+        if "tracks" in items and items["tracks"]:
+            tracks_to_remove = [
+                track for track in items["tracks"] if track.get("videoId") in tracks
+            ]
+
+            if tracks_to_remove:
+                self.api.remove_playlist_items(playlistId, tracks_to_remove)
+
     def remove_songs(self, playlistId):
         items = self.api.get_playlist(playlistId, 10000)
         if "tracks" in items:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ class TestCli(unittest.TestCase):
         args = get_args(["create", "playlist-link"])
         self.assertEqual(len(vars(args)), 10)
         args = get_args(["update", "playlist-link", "playlist-name"])
-        self.assertEqual(len(vars(args)), 7)
+        self.assertEqual(len(vars(args)), 8)
         args = get_args(["liked"])
         self.assertEqual(len(vars(args)), 9)
         args = get_args(["search", "link"])
@@ -74,6 +74,20 @@ class TestCli(unittest.TestCase):
             assert (
                 int(fakeOutput.getvalue().splitlines()[-1][0]) >= 2
             )  # assert number of lines deleted
+
+    def test_update(self):
+        with mock.patch(
+            "sys.argv",
+            [
+                "",
+                "update",
+                TEST_PLAYLIST,
+                "spotify_to_ytmusic",
+                "--append",
+                "--remove-extra",
+            ],
+        ):
+            main()
 
     def test_search(self):
         with mock.patch("sys.argv", ["", "search", TEST_SONG]):

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,0 +1,38 @@
+import unittest
+from spotify_to_ytmusic.ytmusic import YTMusicTransfer
+
+
+class TestYTMusic(unittest.TestCase):
+    def setUp(self):
+        self.ytmusic = YTMusicTransfer()
+        self.playlist_name = "spotify_to_ytmusic"
+        self.playlistId = self.ytmusic.get_playlist_id(self.playlist_name)
+
+    def test_get_playlist_videoIds(self):
+        """Test retrieving video IDs from a YouTube Music playlist."""
+        video_ids = self.ytmusic.get_playlist_videoIds(self.playlistId)
+        print("Fetched video IDs:", video_ids)
+        self.assertIsInstance(video_ids, list)
+        if video_ids:
+            self.assertIsInstance(video_ids[0], str)
+
+    def test_remove_specified_tracks(self):
+        """Test removing two tracks from a YouTube Music playlist."""
+        video_ids = self.ytmusic.get_playlist_videoIds(self.playlistId)
+        print("Before Removal:", video_ids)
+
+        if len(video_ids) < 2:
+            self.skipTest("Not enough tracks in the playlist to test removal.")
+
+        tracks_to_remove = video_ids[:2]  # Remove first 2 tracks
+        self.ytmusic.remove_specified_tracks(self.playlistId, tracks_to_remove)
+
+        updated_video_ids = self.ytmusic.get_playlist_videoIds(self.playlistId)
+        print("After Removal:", updated_video_ids)
+
+        for track in tracks_to_remove:
+            self.assertNotIn(track, updated_video_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **Changelog**  

**Fixed Issues and Improvements:**  
- **Append Mode Fix:**  
  - **Issue:** Append mode previously failed due to duplicate `videoIds` and instances where `videoIds` redirected to different `videoIds` (this causes the duplicate issue).  
  - **Solution:** Identify problematic ids one by one and skip them (while also notifying user of the issue).  

- **Request Timeout (`remove_songs`):**  
  - **Issue:** The playlist update function would sometimes fail when removing all tracks due to a request timeout.  
  - **Solution:** The function `remove_songs` now makes **5 attempts** to remove all tracks.  

- **Update Spotify Liked Playlist:**  
  - Added the ability to update a YTMusic playlist with Spotify liked playlist.

The current implementation will also allow users to merge any Spotify playlist with target YTMusic playlist using `--append` since duplicates are skipped (although it could be a very slow process)