### PR TITLE
fix: use IP for spotify

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Setup
 For backwards compatibility you can also create your own file and pass it using ``--file settings.ini``.
 
 If you want to transfer private playlists from Spotify (i.e. liked songs), choose "yes" for oAuth authentication, otherwise choose "no".
-For oAuth authentication you should set ``http://localhost`` as redirect URI for your app in Spotify's developer dashboard.
+For oAuth authentication you should set ``https://127.0.0.1`` as redirect URI for your app in Spotify's developer dashboard.
 
 Usage
 ------
@@ -99,7 +99,7 @@ Transfer liked tracks of the Spotify user
    spotify_to_ytmusic liked
 
 This command will open browser where you should give access to your account (if you haven't done that before).
-After authorization you will be redirected to localhost, copy link you were redirected to (looks like localhost/?code=...) and paste to command line.
+After authorization you will be redirected to 127.0.0.1, copy link you were redirected to (looks like 127.0.0.1/?code=...) and paste to command line.
 
 Command line options
 ---------------------

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -33,7 +33,7 @@ class Spotify:
             auth = SpotifyOAuth(
                 client_id=client_id,
                 client_secret=client_secret,
-                redirect_uri="http://localhost",
+                redirect_uri="https://127.0.0.1",
                 scope="user-library-read",
                 cache_handler=cache_handler,
                 open_browser=has_browser(),


### PR DESCRIPTION
localhost is deprecated and script used http which is no longer allowed, thus auth didn't work.