### PR TITLE
Spotify api update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ noresults.txt
 !tests/mock_fixtures/mocked_get_large_playlist_response.json
 !tests/mock_fixtures/mocked_get_playlist_response.json
 !tests/mock_fixtures/mocked_ytm_oauth.json
+!tests/mock_fixtures/mocked_get_user_playlists_response.json
 
 #PDM
 .pdm-python

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+junit.xml
 
 # Translations
 *.mo
@@ -111,6 +112,11 @@ noresults.txt
 *.ini
 *.txt
 *.json
+!tests/mock_fixtures/mocked_get_large_playlist_items_response_page_2.json
+!tests/mock_fixtures/mocked_get_large_playlist_items_response_page_3.json
+!tests/mock_fixtures/mocked_get_large_playlist_response.json
+!tests/mock_fixtures/mocked_get_playlist_response.json
+!tests/mock_fixtures/mocked_ytm_oauth.json
 
 #PDM
 .pdm-python

--- a/README.rst
+++ b/README.rst
@@ -76,18 +76,20 @@ After you've completed setup, you can simply run the script from the command lin
 
     spotify_to_ytmusic create <spotifylink>
 
-where ``<spotifylink>`` is a link like https://open.spotify.com/playlist/0S0cuX8pnvmF7gA47Eu63M
+where ``<spotifylink>`` is a link like https://open.spotify.com/playlist/0S0cuX8pnvmF7gA47Eu63M that belongs to the **USER**. Due to the recent `Spotify API Changes <https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security>`_ as of February 11, 2025, accessing tracks from public playlists not owned by the user is no longer possible.
 
 The script will log its progress and output songs that were not found in YouTube Music to **noresults_youtube.txt**.
 
-Transfer all playlists of a Spotify user
-----------------------------------------
+Transfer all playlists of a Spotify user [DEPRECATED]
+-----------------------------------------------------
 
 For migration purposes, it is possible to transfer all public playlists of a user by using the Spotify user's ID (unique username).
 
 .. code-block::
 
     spotify_to_ytmusic all <spotifyuserid>
+
+Due to recent `Spotify API Changes <https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security>`_ as of February 11, 2025, this is no longer possible.
 
 Transfer liked tracks of the Spotify user
 -----------------------------------------
@@ -129,7 +131,6 @@ Available subcommands:
         create              Create a new playlist on YouTube Music.
         update              Delete all entries in the provided Google Play Music playlist and update the playlist with entries from the Spotify playlist.
         remove              Remove playlists with specified regex pattern.
-        all                 Transfer all public playlists of the specified user (Spotify User ID).
-
+        all                 Transfer all public playlists of the specified user (Spotify User ID). [DEPRECATED]
     options:
       -h, --help            show this help message and exit

--- a/README.rst
+++ b/README.rst
@@ -80,16 +80,14 @@ where ``<spotifylink>`` is a link like https://open.spotify.com/playlist/0S0cuX8
 
 The script will log its progress and output songs that were not found in YouTube Music to **noresults_youtube.txt**.
 
-Transfer all playlists of a Spotify user [DEPRECATED]
------------------------------------------------------
+Transfer all playlists of a Spotify user
+----------------------------------------
 
 For migration purposes, it is possible to transfer all public playlists of a user by using the Spotify user's ID (unique username).
 
 .. code-block::
 
     spotify_to_ytmusic all <spotifyuserid>
-
-Due to recent `Spotify API Changes <https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security>`_ as of February 11, 2025, this is no longer possible.
 
 Transfer liked tracks of the Spotify user
 -----------------------------------------
@@ -131,6 +129,6 @@ Available subcommands:
         create              Create a new playlist on YouTube Music.
         update              Delete all entries in the provided Google Play Music playlist and update the playlist with entries from the Spotify playlist.
         remove              Remove playlists with specified regex pattern.
-        all                 Transfer all public playlists of the specified user (Spotify User ID). [DEPRECATED]
+        all                 Transfer all public playlists of the specified user (Spotify User ID).
     options:
       -h, --help            show this help message and exit

--- a/pdm.lock
+++ b/pdm.lock
@@ -545,7 +545,7 @@ files = [
 
 [[package]]
 name = "spotipy"
-version = "2.25.0"
+version = "2.26.0"
 requires_python = ">3.8"
 summary = "A light weight Python library for the Spotify Web API"
 groups = ["default"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "ytmusicapi>=1.11.0rc1",
-    "spotipy>=2.25.0",
+    "spotipy>=2.26.0",
     "platformdirs>=3.2",
 ]
 dynamic = ["version", "readme"]

--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -31,30 +31,8 @@ def _init():
 
 
 def all(args):
-    spotify, ytmusic = _init()
-    pl = spotify.getUserPlaylists(args.user)
-    print(str(len(pl)) + " playlists found. Starting transfer...")
-    count = 1
-    for p in pl:
-        print("Playlist " + str(count) + ": " + p["name"])
-        count = count + 1
-        try:
-            playlist = spotify.getSpotifyPlaylist(p["external_urls"]["spotify"])
-            videoIds = ytmusic.search_songs(
-                playlist["tracks"], use_cached=args.use_cached
-            )
-            playlist_id = ytmusic.create_playlist(
-                p["name"],
-                p["description"],
-                "PUBLIC" if p["public"] else "PRIVATE",
-                videoIds,
-            )
-            if args.like:
-                for id in videoIds:
-                    ytmusic.rate_song(id, "LIKE")
-            _print_success(p["name"], playlist_id)
-        except Exception as ex:
-            print(f"Could not transfer playlist {p['name']}. {ex!s}")
+    print("----------ALL HAS BEEN DEPRECATED DUE TO RECENT SPOTIFY API CHANGES----------")
+    print("----------Please use spotify_to_ytmusic create <spotifylink> to transfer a playlist associated with your spotify account. Public playlists not tied to your spotify account are no longer allowed----------")
 
 
 def _create_ytmusic(args, playlist, ytmusic):

--- a/spotify_to_ytmusic/controllers.py
+++ b/spotify_to_ytmusic/controllers.py
@@ -31,9 +31,30 @@ def _init():
 
 
 def all(args):
-    print("----------ALL HAS BEEN DEPRECATED DUE TO RECENT SPOTIFY API CHANGES----------")
-    print("----------Please use spotify_to_ytmusic create <spotifylink> to transfer a playlist associated with your spotify account. Public playlists not tied to your spotify account are no longer allowed----------")
-
+    spotify, ytmusic = _init()
+    pl = spotify.getUserPlaylists(args.user)
+    print(str(len(pl)) + " playlists found. Starting transfer...")
+    count = 1
+    for p in pl:
+        print("Playlist " + str(count) + ": " + p["name"])
+        count = count + 1
+        try:
+            playlist = spotify.getSpotifyPlaylist(p["external_urls"]["spotify"])
+            videoIds = ytmusic.search_songs(
+                playlist["tracks"], use_cached=args.use_cached
+            )
+            playlist_id = ytmusic.create_playlist(
+                p["name"],
+                p["description"],
+                "PUBLIC" if p["public"] else "PRIVATE",
+                videoIds,
+            )
+            if args.like:
+                for id in videoIds:
+                    ytmusic.rate_song(id, "LIKE")
+            _print_success(p["name"], playlist_id)
+        except Exception as ex:
+            print(f"Could not transfer playlist {p['name']}. {ex!s}")
 
 def _create_ytmusic(args, playlist, ytmusic):
     date = ""

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -53,14 +53,14 @@ class Spotify:
         print("Getting Spotify tracks...")
         results = self.api.playlist(playlistId)
         name = results["name"]
-        total = int(results["tracks"]["total"])
-        tracks = build_results(results["tracks"]["items"])
+        total = int(results["items"]["total"])
+        tracks = build_results(results["items"]["items"], nested_key = "item")
         count = len(tracks)
         print(f"Spotify tracks: {count}/{total}")
 
         while count < total:
             more_tracks = self.api.playlist_items(playlistId, offset=count, limit=100)
-            tracks += build_results(more_tracks["items"])
+            tracks += build_results(more_tracks["items"], nested_key = "item")
             count = count + 100
             print(f"Spotify tracks: {len(tracks)}/{total}")
 
@@ -69,18 +69,6 @@ class Spotify:
             "name": name,
             "description": html.unescape(results["description"]),
         }
-
-    def getUserPlaylists(self, user):
-        pl = self.api.user_playlists(user)["items"]
-        count = 1
-        more = len(pl) == 50
-        while more:
-            results = self.api.user_playlists(user, offset=count * 50)["items"]
-            pl.extend(results)
-            more = len(results) == 50
-            count = count + 1
-
-        return [p for p in pl if p["owner"]["id"] == user and p["tracks"]["total"] > 0]
 
     def getLikedPlaylist(self):
         response = self.api.current_user_saved_tracks(limit=50)
@@ -92,7 +80,7 @@ class Spotify:
             tracks.extend(response["items"])
 
         return {
-            "tracks": build_results(tracks),
+            "tracks" :  build_results(tracks, nested_key="track"),
             "name": "Liked songs (Spotify)",
             "description": "Your liked tracks from spotify",
         }
@@ -101,11 +89,11 @@ class Spotify:
         return self.api.track(song_url)
 
 
-def build_results(tracks, album=None):
+def build_results(tracks, nested_key, album=None):
     results = []
     for track in tracks:
-        if "track" in track:
-            track = track["track"]
+        if nested_key in track:
+            track = track[nested_key]
         if not track or track["duration_ms"] == 0:
             continue
         album_name = album if album else track["album"]["name"]
@@ -119,7 +107,6 @@ def build_results(tracks, album=None):
         )
 
     return results
-
 
 def extract_playlist_id_from_url(url: str) -> str:
     if match := re.search(r"playlist\/(?P<id>\w{22})\W?", url):

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -80,9 +80,7 @@ class Spotify:
             more = len(results) == 50
             count = count + 1
 
-        user_playlists = [p for p in pl if p["owner"]["id"] == user and p["items"]["total"] > 0]
-        print(f"user owned playlists found - {len(user_playlists)}")
-        return user_playlists
+        return [p for p in pl if p["owner"]["id"] == user and p["items"]["total"] > 0]
 
     def getLikedPlaylist(self):
         response = self.api.current_user_saved_tracks(limit=50)

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -80,7 +80,7 @@ class Spotify:
             tracks.extend(response["items"])
 
         return {
-            "tracks" :  build_results(tracks, nested_key="track"),
+            "tracks":  build_results(tracks, nested_key="track"),
             "name": "Liked songs (Spotify)",
             "description": "Your liked tracks from spotify",
         }

--- a/spotify_to_ytmusic/spotify.py
+++ b/spotify_to_ytmusic/spotify.py
@@ -69,6 +69,20 @@ class Spotify:
             "name": name,
             "description": html.unescape(results["description"]),
         }
+    
+    def getUserPlaylists(self, user):
+        pl = self.api.user_playlists(user)["items"]
+        count = 1
+        more = len(pl) == 50
+        while more:
+            results = self.api.user_playlists(user, offset=count * 50)["items"]
+            pl.extend(results)
+            more = len(results) == 50
+            count = count + 1
+
+        user_playlists = [p for p in pl if p["owner"]["id"] == user and p["items"]["total"] > 0]
+        print(f"user owned playlists found - {len(user_playlists)}")
+        return user_playlists
 
     def getLikedPlaylist(self):
         response = self.api.current_user_saved_tracks(limit=50)

--- a/tests/mock_fixtures/mocked_get_large_playlist_items_response_page_2.json
+++ b/tests/mock_fixtures/mocked_get_large_playlist_items_response_page_2.json
@@ -1,0 +1,11910 @@
+{
+  "href": "https://api.spotify.com/v1/playlists/testId/items?offset=100&limit=100",
+  "items": [
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7KJTuTXYSnBGNgAxte3CSg",
+          "id": "7KJTuTXYSnBGNgAxte3CSg",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273aeec124221f2c23932be51b2",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02aeec124221f2c23932be51b2",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851aeec124221f2c23932be51b2",
+              "width": 64
+            }
+          ],
+          "name": "No Sleep (feat. Bonn)",
+          "release_date": "2019-02-21",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7KJTuTXYSnBGNgAxte3CSg",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7KJTuTXYSnBGNgAxte3CSg"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+            },
+            "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+            "id": "7Io0XduXk7aOHFHA7sLru2",
+            "name": "Bonn",
+            "type": "artist",
+            "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 207094,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1ahVFh0ViDZr8LvkEVlq3B"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1ahVFh0ViDZr8LvkEVlq3B",
+        "id": "1ahVFh0ViDZr8LvkEVlq3B",
+        "name": "No Sleep (feat. Bonn)",
+        "uri": "spotify:track:1ahVFh0ViDZr8LvkEVlq3B",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1riRLxtA9wK13t7wxmKCNC",
+          "id": "1riRLxtA9wK13t7wxmKCNC",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273fdccc232ddfeb687bef30b44",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02fdccc232ddfeb687bef30b44",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851fdccc232ddfeb687bef30b44",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer (Remixes Vol. 2)",
+          "release_date": "2018-12-28",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1riRLxtA9wK13t7wxmKCNC",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1riRLxtA9wK13t7wxmKCNC"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 185624,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7xNJVMsqGS0R0FXM4iObeV"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7xNJVMsqGS0R0FXM4iObeV",
+        "id": "7xNJVMsqGS0R0FXM4iObeV",
+        "name": "Dreamer - Brooks Remix",
+        "uri": "spotify:track:7xNJVMsqGS0R0FXM4iObeV",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1riRLxtA9wK13t7wxmKCNC",
+          "id": "1riRLxtA9wK13t7wxmKCNC",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273fdccc232ddfeb687bef30b44",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02fdccc232ddfeb687bef30b44",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851fdccc232ddfeb687bef30b44",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer (Remixes Vol. 2)",
+          "release_date": "2018-12-28",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1riRLxtA9wK13t7wxmKCNC",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1riRLxtA9wK13t7wxmKCNC"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3m0nlOTs9bT1TgM5UyPKXY"
+            },
+            "href": "https://api.spotify.com/v1/artists/3m0nlOTs9bT1TgM5UyPKXY",
+            "id": "3m0nlOTs9bT1TgM5UyPKXY",
+            "name": "Infuze",
+            "type": "artist",
+            "uri": "spotify:artist:3m0nlOTs9bT1TgM5UyPKXY"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 230952,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4F7UuAMcm9eE48QHcDQmc1"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4F7UuAMcm9eE48QHcDQmc1",
+        "id": "4F7UuAMcm9eE48QHcDQmc1",
+        "name": "Dreamer - Infuze Remix",
+        "uri": "spotify:track:4F7UuAMcm9eE48QHcDQmc1",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1riRLxtA9wK13t7wxmKCNC",
+          "id": "1riRLxtA9wK13t7wxmKCNC",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273fdccc232ddfeb687bef30b44",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02fdccc232ddfeb687bef30b44",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851fdccc232ddfeb687bef30b44",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer (Remixes Vol. 2)",
+          "release_date": "2018-12-28",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1riRLxtA9wK13t7wxmKCNC",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1riRLxtA9wK13t7wxmKCNC"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4nKvbonPefiFmshjpHENVU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4nKvbonPefiFmshjpHENVU",
+            "id": "4nKvbonPefiFmshjpHENVU",
+            "name": "SLVR",
+            "type": "artist",
+            "uri": "spotify:artist:4nKvbonPefiFmshjpHENVU"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 175324,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2FQ61tMAfg4DM4Jp6etj6t"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2FQ61tMAfg4DM4Jp6etj6t",
+        "id": "2FQ61tMAfg4DM4Jp6etj6t",
+        "name": "Dreamer - SLVR Booshi Remix",
+        "uri": "spotify:track:2FQ61tMAfg4DM4Jp6etj6t",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1Vb1gttHEF1ehOTvga4VSM",
+          "id": "1Vb1gttHEF1ehOTvga4VSM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2732ae28ceac88b7e2780dd7f2a",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e022ae28ceac88b7e2780dd7f2a",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048512ae28ceac88b7e2780dd7f2a",
+              "width": 64
+            }
+          ],
+          "name": "Glitch",
+          "release_date": "2018-12-14",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1Vb1gttHEF1ehOTvga4VSM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+              "id": "2vUCVkeZjzDcaoX4gagHdV",
+              "name": "Julian Jordan",
+              "type": "artist",
+              "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1Vb1gttHEF1ehOTvga4VSM"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+            },
+            "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+            "id": "2vUCVkeZjzDcaoX4gagHdV",
+            "name": "Julian Jordan",
+            "type": "artist",
+            "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 185161,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/47knrBbYhqtrggWYSkU6h1"
+        },
+        "href": "https://api.spotify.com/v1/tracks/47knrBbYhqtrggWYSkU6h1",
+        "id": "47knrBbYhqtrggWYSkU6h1",
+        "name": "Glitch",
+        "uri": "spotify:track:47knrBbYhqtrggWYSkU6h1",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/05anULzMxwpFurSgQ0WLNk",
+          "id": "05anULzMxwpFurSgQ0WLNk",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273afcebf2de8d53d5a5d7b09dd",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02afcebf2de8d53d5a5d7b09dd",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851afcebf2de8d53d5a5d7b09dd",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer (Remixes Vol. 1)",
+          "release_date": "2018-12-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:05anULzMxwpFurSgQ0WLNk",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+              },
+              "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+              "id": "5ChF3i92IPZHduM7jN3dpg",
+              "name": "Nicky Romero",
+              "type": "artist",
+              "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/05anULzMxwpFurSgQ0WLNk"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+            },
+            "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+            "id": "5ChF3i92IPZHduM7jN3dpg",
+            "name": "Nicky Romero",
+            "type": "artist",
+            "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 224761,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/58ctD8HaEUXJkdv7TTsmG8"
+        },
+        "href": "https://api.spotify.com/v1/tracks/58ctD8HaEUXJkdv7TTsmG8",
+        "id": "58ctD8HaEUXJkdv7TTsmG8",
+        "name": "Dreamer - Nicky Romero Remix",
+        "uri": "spotify:track:58ctD8HaEUXJkdv7TTsmG8",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/05anULzMxwpFurSgQ0WLNk",
+          "id": "05anULzMxwpFurSgQ0WLNk",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273afcebf2de8d53d5a5d7b09dd",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02afcebf2de8d53d5a5d7b09dd",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851afcebf2de8d53d5a5d7b09dd",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer (Remixes Vol. 1)",
+          "release_date": "2018-12-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:05anULzMxwpFurSgQ0WLNk",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+              },
+              "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+              "id": "5ChF3i92IPZHduM7jN3dpg",
+              "name": "Nicky Romero",
+              "type": "artist",
+              "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/05anULzMxwpFurSgQ0WLNk"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6jjKAAi2ahf5gQ37k7rJya"
+            },
+            "href": "https://api.spotify.com/v1/artists/6jjKAAi2ahf5gQ37k7rJya",
+            "id": "6jjKAAi2ahf5gQ37k7rJya",
+            "name": "EAUXMAR",
+            "type": "artist",
+            "uri": "spotify:artist:6jjKAAi2ahf5gQ37k7rJya"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 178000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4GOWmlSYxTMefRA47H3EMN"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4GOWmlSYxTMefRA47H3EMN",
+        "id": "4GOWmlSYxTMefRA47H3EMN",
+        "name": "Dreamer - EAUXMAR Remix",
+        "uri": "spotify:track:4GOWmlSYxTMefRA47H3EMN",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/05anULzMxwpFurSgQ0WLNk",
+          "id": "05anULzMxwpFurSgQ0WLNk",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273afcebf2de8d53d5a5d7b09dd",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02afcebf2de8d53d5a5d7b09dd",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851afcebf2de8d53d5a5d7b09dd",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer (Remixes Vol. 1)",
+          "release_date": "2018-12-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:05anULzMxwpFurSgQ0WLNk",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+              },
+              "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+              "id": "5ChF3i92IPZHduM7jN3dpg",
+              "name": "Nicky Romero",
+              "type": "artist",
+              "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/05anULzMxwpFurSgQ0WLNk"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4nKvbonPefiFmshjpHENVU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4nKvbonPefiFmshjpHENVU",
+            "id": "4nKvbonPefiFmshjpHENVU",
+            "name": "SLVR",
+            "type": "artist",
+            "uri": "spotify:artist:4nKvbonPefiFmshjpHENVU"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 171750,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6eyU4mAkFLLs6IOVPwLU7H"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6eyU4mAkFLLs6IOVPwLU7H",
+        "id": "6eyU4mAkFLLs6IOVPwLU7H",
+        "name": "Dreamer - SLVR Remix",
+        "uri": "spotify:track:6eyU4mAkFLLs6IOVPwLU7H",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/4D13M99kn4kSlPt5ZtYy8R",
+          "id": "4D13M99kn4kSlPt5ZtYy8R",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a55f8100a9b21d08e4090ee5",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a55f8100a9b21d08e4090ee5",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a55f8100a9b21d08e4090ee5",
+              "width": 64
+            }
+          ],
+          "name": "Dreamer",
+          "release_date": "2018-11-01",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4D13M99kn4kSlPt5ZtYy8R",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+              "id": "4UffC3o3JiLSg7pa5DpQbp",
+              "name": "Mike Yung",
+              "type": "artist",
+              "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4D13M99kn4kSlPt5ZtYy8R"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UffC3o3JiLSg7pa5DpQbp"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UffC3o3JiLSg7pa5DpQbp",
+            "id": "4UffC3o3JiLSg7pa5DpQbp",
+            "name": "Mike Yung",
+            "type": "artist",
+            "uri": "spotify:artist:4UffC3o3JiLSg7pa5DpQbp"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 193399,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0wUxh6XMc698xPCfgBaPRV"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0wUxh6XMc698xPCfgBaPRV",
+        "id": "0wUxh6XMc698xPCfgBaPRV",
+        "name": "Dreamer",
+        "uri": "spotify:track:0wUxh6XMc698xPCfgBaPRV",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5dv1oLETxdsYOkS2Sic00z",
+          "id": "5dv1oLETxdsYOkS2Sic00z",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27339a66c9851771f1770c20313",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0239a66c9851771f1770c20313",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485139a66c9851771f1770c20313",
+              "width": 64
+            }
+          ],
+          "name": "BYLAW EP",
+          "release_date": "2018-10-19",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dv1oLETxdsYOkS2Sic00z",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dv1oLETxdsYOkS2Sic00z"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5p0zkKpBuRguKebwRe0RI2"
+            },
+            "href": "https://api.spotify.com/v1/artists/5p0zkKpBuRguKebwRe0RI2",
+            "id": "5p0zkKpBuRguKebwRe0RI2",
+            "name": "Pierce Fulton",
+            "type": "artist",
+            "uri": "spotify:artist:5p0zkKpBuRguKebwRe0RI2"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6xBZgSMsnKVmaAxzWEwMSD"
+            },
+            "href": "https://api.spotify.com/v1/artists/6xBZgSMsnKVmaAxzWEwMSD",
+            "id": "6xBZgSMsnKVmaAxzWEwMSD",
+            "name": "Mike Shinoda",
+            "type": "artist",
+            "uri": "spotify:artist:6xBZgSMsnKVmaAxzWEwMSD"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 247504,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/27YP211Rr8RezhiFVDLFI8"
+        },
+        "href": "https://api.spotify.com/v1/tracks/27YP211Rr8RezhiFVDLFI8",
+        "id": "27YP211Rr8RezhiFVDLFI8",
+        "name": "Waiting For Tomorrow (feat. Mike Shinoda)",
+        "uri": "spotify:track:27YP211Rr8RezhiFVDLFI8",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5dv1oLETxdsYOkS2Sic00z",
+          "id": "5dv1oLETxdsYOkS2Sic00z",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27339a66c9851771f1770c20313",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0239a66c9851771f1770c20313",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485139a66c9851771f1770c20313",
+              "width": 64
+            }
+          ],
+          "name": "BYLAW EP",
+          "release_date": "2018-10-19",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dv1oLETxdsYOkS2Sic00z",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dv1oLETxdsYOkS2Sic00z"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 195454,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4cBSVGEHvZCPGKq2UnB26P"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4cBSVGEHvZCPGKq2UnB26P",
+        "id": "4cBSVGEHvZCPGKq2UnB26P",
+        "name": "Access",
+        "uri": "spotify:track:4cBSVGEHvZCPGKq2UnB26P",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5dv1oLETxdsYOkS2Sic00z",
+          "id": "5dv1oLETxdsYOkS2Sic00z",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27339a66c9851771f1770c20313",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0239a66c9851771f1770c20313",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485139a66c9851771f1770c20313",
+              "width": 64
+            }
+          ],
+          "name": "BYLAW EP",
+          "release_date": "2018-10-19",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dv1oLETxdsYOkS2Sic00z",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dv1oLETxdsYOkS2Sic00z"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/03MVmfitJTVJIxYmObhQn9"
+            },
+            "href": "https://api.spotify.com/v1/artists/03MVmfitJTVJIxYmObhQn9",
+            "id": "03MVmfitJTVJIxYmObhQn9",
+            "name": "Dyro",
+            "type": "artist",
+            "uri": "spotify:artist:03MVmfitJTVJIxYmObhQn9"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 204375,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5w00Xed2Okc8qZ9s5zOhbe"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5w00Xed2Okc8qZ9s5zOhbe",
+        "id": "5w00Xed2Okc8qZ9s5zOhbe",
+        "name": "Latency",
+        "uri": "spotify:track:5w00Xed2Okc8qZ9s5zOhbe",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5dv1oLETxdsYOkS2Sic00z",
+          "id": "5dv1oLETxdsYOkS2Sic00z",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27339a66c9851771f1770c20313",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0239a66c9851771f1770c20313",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485139a66c9851771f1770c20313",
+              "width": 64
+            }
+          ],
+          "name": "BYLAW EP",
+          "release_date": "2018-10-19",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dv1oLETxdsYOkS2Sic00z",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dv1oLETxdsYOkS2Sic00z"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 210004,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1PYsy4cGp3egbeaQDjIGIa"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1PYsy4cGp3egbeaQDjIGIa",
+        "id": "1PYsy4cGp3egbeaQDjIGIa",
+        "name": "Yottabyte",
+        "uri": "spotify:track:1PYsy4cGp3egbeaQDjIGIa",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5dv1oLETxdsYOkS2Sic00z",
+          "id": "5dv1oLETxdsYOkS2Sic00z",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27339a66c9851771f1770c20313",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0239a66c9851771f1770c20313",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485139a66c9851771f1770c20313",
+              "width": 64
+            }
+          ],
+          "name": "BYLAW EP",
+          "release_date": "2018-10-19",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dv1oLETxdsYOkS2Sic00z",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dv1oLETxdsYOkS2Sic00z"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/26JVnujQQ3lEML8t9p3X1J"
+            },
+            "href": "https://api.spotify.com/v1/artists/26JVnujQQ3lEML8t9p3X1J",
+            "id": "26JVnujQQ3lEML8t9p3X1J",
+            "name": "Blinders",
+            "type": "artist",
+            "uri": "spotify:artist:26JVnujQQ3lEML8t9p3X1J"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 178125,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5UHrKSQhNs96msAx8LPVwS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5UHrKSQhNs96msAx8LPVwS",
+        "id": "5UHrKSQhNs96msAx8LPVwS",
+        "name": "Breach (Walk Alone)",
+        "uri": "spotify:track:5UHrKSQhNs96msAx8LPVwS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3feYPmyPH7tqh1ZfsU0D0i",
+          "id": "3feYPmyPH7tqh1ZfsU0D0i",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273c83edc0f622614c4b577665a",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02c83edc0f622614c4b577665a",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851c83edc0f622614c4b577665a",
+              "width": 64
+            }
+          ],
+          "name": "Burn Out (feat. Dewain Whitmore)",
+          "release_date": "2018-09-14",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3feYPmyPH7tqh1ZfsU0D0i",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7MFJyevu6jq0shwDuVLymu"
+              },
+              "href": "https://api.spotify.com/v1/artists/7MFJyevu6jq0shwDuVLymu",
+              "id": "7MFJyevu6jq0shwDuVLymu",
+              "name": "Justin Mylo",
+              "type": "artist",
+              "uri": "spotify:artist:7MFJyevu6jq0shwDuVLymu"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3feYPmyPH7tqh1ZfsU0D0i"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7MFJyevu6jq0shwDuVLymu"
+            },
+            "href": "https://api.spotify.com/v1/artists/7MFJyevu6jq0shwDuVLymu",
+            "id": "7MFJyevu6jq0shwDuVLymu",
+            "name": "Justin Mylo",
+            "type": "artist",
+            "uri": "spotify:artist:7MFJyevu6jq0shwDuVLymu"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1E1W3to8HhGSkkIEUMwEjd"
+            },
+            "href": "https://api.spotify.com/v1/artists/1E1W3to8HhGSkkIEUMwEjd",
+            "id": "1E1W3to8HhGSkkIEUMwEjd",
+            "name": "Dewain Whitmore",
+            "type": "artist",
+            "uri": "spotify:artist:1E1W3to8HhGSkkIEUMwEjd"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 200332,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7IWTIkiWGWNQyYfOLdMrGD"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7IWTIkiWGWNQyYfOLdMrGD",
+        "id": "7IWTIkiWGWNQyYfOLdMrGD",
+        "name": "Burn Out (feat. Dewain Whitmore)",
+        "uri": "spotify:track:7IWTIkiWGWNQyYfOLdMrGD",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1GUfof1gHsqYjoHFym3aim",
+          "id": "1GUfof1gHsqYjoHFym3aim",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273def05abd2a12cd19243e2b6d",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02def05abd2a12cd19243e2b6d",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851def05abd2a12cd19243e2b6d",
+              "width": 64
+            }
+          ],
+          "name": "High On Life (feat. Bonn)",
+          "release_date": "2018-07-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1GUfof1gHsqYjoHFym3aim",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1GUfof1gHsqYjoHFym3aim"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+            },
+            "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+            "id": "7Io0XduXk7aOHFHA7sLru2",
+            "name": "Bonn",
+            "type": "artist",
+            "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 230761,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4ut5G4rgB1ClpMTMfjoIuy"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4ut5G4rgB1ClpMTMfjoIuy",
+        "id": "4ut5G4rgB1ClpMTMfjoIuy",
+        "name": "High On Life (feat. Bonn)",
+        "uri": "spotify:track:4ut5G4rgB1ClpMTMfjoIuy",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2lYxgMaJP2bGy4dhIToqzS",
+          "id": "2lYxgMaJP2bGy4dhIToqzS",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2730407c332a2c4b735952faf07",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e020407c332a2c4b735952faf07",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048510407c332a2c4b735952faf07",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [David Guetta Remix]",
+          "release_date": "2018-08-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2lYxgMaJP2bGy4dhIToqzS",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2lYxgMaJP2bGy4dhIToqzS"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 195832,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2Ceq5Ty6rJqazoZIWyS0Vc"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2Ceq5Ty6rJqazoZIWyS0Vc",
+        "id": "2Ceq5Ty6rJqazoZIWyS0Vc",
+        "name": "Ocean (feat. Khalid) - David Guetta Remix",
+        "uri": "spotify:track:2Ceq5Ty6rJqazoZIWyS0Vc",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/431MGLLYepIfe6VsSO4pzO",
+          "id": "431MGLLYepIfe6VsSO4pzO",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2736a171675d9c35bfa15a03660",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e026a171675d9c35bfa15a03660",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048516a171675d9c35bfa15a03660",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Don Diablo Remix]",
+          "release_date": "2018-08-10",
+          "release_date_precision": "day",
+          "uri": "spotify:album:431MGLLYepIfe6VsSO4pzO",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1l2ekx5skC4gJH8djERwh1"
+              },
+              "href": "https://api.spotify.com/v1/artists/1l2ekx5skC4gJH8djERwh1",
+              "id": "1l2ekx5skC4gJH8djERwh1",
+              "name": "Don Diablo",
+              "type": "artist",
+              "uri": "spotify:artist:1l2ekx5skC4gJH8djERwh1"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/431MGLLYepIfe6VsSO4pzO"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1l2ekx5skC4gJH8djERwh1"
+            },
+            "href": "https://api.spotify.com/v1/artists/1l2ekx5skC4gJH8djERwh1",
+            "id": "1l2ekx5skC4gJH8djERwh1",
+            "name": "Don Diablo",
+            "type": "artist",
+            "uri": "spotify:artist:1l2ekx5skC4gJH8djERwh1"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 202926,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4oOQ5XZuR4ywDje9SjiA7d"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4oOQ5XZuR4ywDje9SjiA7d",
+        "id": "4oOQ5XZuR4ywDje9SjiA7d",
+        "name": "Ocean (feat. Khalid) - Don Diablo Remix",
+        "uri": "spotify:track:4oOQ5XZuR4ywDje9SjiA7d",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/65DPGhPoRUITNLgUmfWBvu",
+          "id": "65DPGhPoRUITNLgUmfWBvu",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735876184bc5df5e9534da48e8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025876184bc5df5e9534da48e8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515876184bc5df5e9534da48e8",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 2]",
+          "release_date": "2018-08-03",
+          "release_date_precision": "day",
+          "uri": "spotify:album:65DPGhPoRUITNLgUmfWBvu",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/65DPGhPoRUITNLgUmfWBvu"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2uFC1dAj5b0YU7vulKNZ0p"
+            },
+            "href": "https://api.spotify.com/v1/artists/2uFC1dAj5b0YU7vulKNZ0p",
+            "id": "2uFC1dAj5b0YU7vulKNZ0p",
+            "name": "Banx & Ranx",
+            "type": "artist",
+            "uri": "spotify:artist:2uFC1dAj5b0YU7vulKNZ0p"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 216572,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3K6u4Zjk76aOgvcbd1Izl0"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3K6u4Zjk76aOgvcbd1Izl0",
+        "id": "3K6u4Zjk76aOgvcbd1Izl0",
+        "name": "Ocean (feat. Khalid) - Banx & Ranx Remix",
+        "uri": "spotify:track:3K6u4Zjk76aOgvcbd1Izl0",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/65DPGhPoRUITNLgUmfWBvu",
+          "id": "65DPGhPoRUITNLgUmfWBvu",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735876184bc5df5e9534da48e8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025876184bc5df5e9534da48e8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515876184bc5df5e9534da48e8",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 2]",
+          "release_date": "2018-08-03",
+          "release_date_precision": "day",
+          "uri": "spotify:album:65DPGhPoRUITNLgUmfWBvu",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/65DPGhPoRUITNLgUmfWBvu"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2zzeaUCFCtQrtFRYoTP7Ru"
+            },
+            "href": "https://api.spotify.com/v1/artists/2zzeaUCFCtQrtFRYoTP7Ru",
+            "id": "2zzeaUCFCtQrtFRYoTP7Ru",
+            "name": "VAN DUO",
+            "type": "artist",
+            "uri": "spotify:artist:2zzeaUCFCtQrtFRYoTP7Ru"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 236302,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3sEC2LO7t4G61WOZjUvm4f"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3sEC2LO7t4G61WOZjUvm4f",
+        "id": "3sEC2LO7t4G61WOZjUvm4f",
+        "name": "Ocean (feat. Khalid) - VAN DUO Remix",
+        "uri": "spotify:track:3sEC2LO7t4G61WOZjUvm4f",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/65DPGhPoRUITNLgUmfWBvu",
+          "id": "65DPGhPoRUITNLgUmfWBvu",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735876184bc5df5e9534da48e8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025876184bc5df5e9534da48e8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515876184bc5df5e9534da48e8",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 2]",
+          "release_date": "2018-08-03",
+          "release_date_precision": "day",
+          "uri": "spotify:album:65DPGhPoRUITNLgUmfWBvu",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/65DPGhPoRUITNLgUmfWBvu"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6i1GVNJCyyssRwXmnaeEFH"
+            },
+            "href": "https://api.spotify.com/v1/artists/6i1GVNJCyyssRwXmnaeEFH",
+            "id": "6i1GVNJCyyssRwXmnaeEFH",
+            "name": "Syn Cole",
+            "type": "artist",
+            "uri": "spotify:artist:6i1GVNJCyyssRwXmnaeEFH"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 202500,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2bSQqpvnfyheVT9jaK3p5g"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2bSQqpvnfyheVT9jaK3p5g",
+        "id": "2bSQqpvnfyheVT9jaK3p5g",
+        "name": "Ocean (feat. Khalid) - Syn Cole Remix",
+        "uri": "spotify:track:2bSQqpvnfyheVT9jaK3p5g",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/65DPGhPoRUITNLgUmfWBvu",
+          "id": "65DPGhPoRUITNLgUmfWBvu",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735876184bc5df5e9534da48e8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025876184bc5df5e9534da48e8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515876184bc5df5e9534da48e8",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 2]",
+          "release_date": "2018-08-03",
+          "release_date_precision": "day",
+          "uri": "spotify:album:65DPGhPoRUITNLgUmfWBvu",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/65DPGhPoRUITNLgUmfWBvu"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/41DKMtAnhVo7aDeluAHDJg"
+            },
+            "href": "https://api.spotify.com/v1/artists/41DKMtAnhVo7aDeluAHDJg",
+            "id": "41DKMtAnhVo7aDeluAHDJg",
+            "name": "MYRNE",
+            "type": "artist",
+            "uri": "spotify:artist:41DKMtAnhVo7aDeluAHDJg"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 223200,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2uYCZFKK7Y6ra12SFkBQrU"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2uYCZFKK7Y6ra12SFkBQrU",
+        "id": "2uYCZFKK7Y6ra12SFkBQrU",
+        "name": "Ocean (feat. Khalid) - MYRNE Remix",
+        "uri": "spotify:track:2uYCZFKK7Y6ra12SFkBQrU",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/65DPGhPoRUITNLgUmfWBvu",
+          "id": "65DPGhPoRUITNLgUmfWBvu",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735876184bc5df5e9534da48e8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025876184bc5df5e9534da48e8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515876184bc5df5e9534da48e8",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 2]",
+          "release_date": "2018-08-03",
+          "release_date_precision": "day",
+          "uri": "spotify:album:65DPGhPoRUITNLgUmfWBvu",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/65DPGhPoRUITNLgUmfWBvu"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2gNmFyBanPG1slh2pHnCtU"
+            },
+            "href": "https://api.spotify.com/v1/artists/2gNmFyBanPG1slh2pHnCtU",
+            "id": "2gNmFyBanPG1slh2pHnCtU",
+            "name": "Holy Goof",
+            "type": "artist",
+            "uri": "spotify:artist:2gNmFyBanPG1slh2pHnCtU"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 347076,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/47AKrHrVUa5XAhhjVc2Kt2"
+        },
+        "href": "https://api.spotify.com/v1/tracks/47AKrHrVUa5XAhhjVc2Kt2",
+        "id": "47AKrHrVUa5XAhhjVc2Kt2",
+        "name": "Ocean (feat. Khalid) - Holy Goof Remix",
+        "uri": "spotify:track:47AKrHrVUa5XAhhjVc2Kt2",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1EAFXic0Cfiwpe7nSuTrGL"
+            },
+            "href": "https://api.spotify.com/v1/artists/1EAFXic0Cfiwpe7nSuTrGL",
+            "id": "1EAFXic0Cfiwpe7nSuTrGL",
+            "name": "Cesqeaux",
+            "type": "artist",
+            "uri": "spotify:artist:1EAFXic0Cfiwpe7nSuTrGL"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 222533,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7tV1uRWqwKyIXfDIX4uJDt"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7tV1uRWqwKyIXfDIX4uJDt",
+        "id": "7tV1uRWqwKyIXfDIX4uJDt",
+        "name": "Ocean (feat. Khalid) - Martin Garrix & Cesqeaux Remix",
+        "uri": "spotify:track:7tV1uRWqwKyIXfDIX4uJDt",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1eOOXqRHILTxqrEUAYyQU0"
+            },
+            "href": "https://api.spotify.com/v1/artists/1eOOXqRHILTxqrEUAYyQU0",
+            "id": "1eOOXqRHILTxqrEUAYyQU0",
+            "name": "Bart B More",
+            "type": "artist",
+            "uri": "spotify:artist:1eOOXqRHILTxqrEUAYyQU0"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 185280,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2Bs3q5N4EfJ1dWrFHWHpls"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2Bs3q5N4EfJ1dWrFHWHpls",
+        "id": "2Bs3q5N4EfJ1dWrFHWHpls",
+        "name": "Ocean (feat. Khalid) - Bart B More Remix",
+        "uri": "spotify:track:2Bs3q5N4EfJ1dWrFHWHpls",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3wRQD6UZWlaWEnbgpIEPPX"
+            },
+            "href": "https://api.spotify.com/v1/artists/3wRQD6UZWlaWEnbgpIEPPX",
+            "id": "3wRQD6UZWlaWEnbgpIEPPX",
+            "name": "Cazztek",
+            "type": "artist",
+            "uri": "spotify:artist:3wRQD6UZWlaWEnbgpIEPPX"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 296640,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4ZE0hbppjr8yhIWktNqi0I"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4ZE0hbppjr8yhIWktNqi0I",
+        "id": "4ZE0hbppjr8yhIWktNqi0I",
+        "name": "Ocean (feat. Khalid) - Cazztek Remix",
+        "uri": "spotify:track:4ZE0hbppjr8yhIWktNqi0I",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6nhsSK9KbToX3Brq0xeWbV"
+            },
+            "href": "https://api.spotify.com/v1/artists/6nhsSK9KbToX3Brq0xeWbV",
+            "id": "6nhsSK9KbToX3Brq0xeWbV",
+            "name": "Todd Helder",
+            "type": "artist",
+            "uri": "spotify:artist:6nhsSK9KbToX3Brq0xeWbV"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 140571,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6Hun7wJk40uuBZuUJZRE4U"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6Hun7wJk40uuBZuUJZRE4U",
+        "id": "6Hun7wJk40uuBZuUJZRE4U",
+        "name": "Ocean (feat. Khalid) - Todd Helder Remix",
+        "uri": "spotify:track:6Hun7wJk40uuBZuUJZRE4U",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/78KwNsjhjWzZYejeBTtsNW"
+            },
+            "href": "https://api.spotify.com/v1/artists/78KwNsjhjWzZYejeBTtsNW",
+            "id": "78KwNsjhjWzZYejeBTtsNW",
+            "name": "Silque",
+            "type": "artist",
+            "uri": "spotify:artist:78KwNsjhjWzZYejeBTtsNW"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 218880,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1UmznbNxlATXSCAHYqvsUf"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1UmznbNxlATXSCAHYqvsUf",
+        "id": "1UmznbNxlATXSCAHYqvsUf",
+        "name": "Ocean (feat. Khalid) - Silque Remix",
+        "uri": "spotify:track:1UmznbNxlATXSCAHYqvsUf",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+            },
+            "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+            "id": "3XINWZaloea97SIRiyTJxX",
+            "name": "DubVision",
+            "type": "artist",
+            "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 6,
+        "duration_ms": 315000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5hxIWOdB3YAwuRMcdYUXNB"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5hxIWOdB3YAwuRMcdYUXNB",
+        "id": "5hxIWOdB3YAwuRMcdYUXNB",
+        "name": "Ocean (feat. Khalid) - DubVision Remix",
+        "uri": "spotify:track:5hxIWOdB3YAwuRMcdYUXNB",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3ruHwnIGTj3Bz0dtS0rhv3",
+          "id": "3ruHwnIGTj3Bz0dtS0rhv3",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273257ea2aad2876e42f2d19667",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02257ea2aad2876e42f2d19667",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851257ea2aad2876e42f2d19667",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid) [Remixes Vol. 1]",
+          "release_date": "2018-07-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3ruHwnIGTj3Bz0dtS0rhv3",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3ruHwnIGTj3Bz0dtS0rhv3"
+          },
+          "total_tracks": 7
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2Gy4HwdmVmRPWDBQO3lw3d"
+            },
+            "href": "https://api.spotify.com/v1/artists/2Gy4HwdmVmRPWDBQO3lw3d",
+            "id": "2Gy4HwdmVmRPWDBQO3lw3d",
+            "name": "Goja",
+            "type": "artist",
+            "uri": "spotify:artist:2Gy4HwdmVmRPWDBQO3lw3d"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 7,
+        "duration_ms": 215795,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/22WDopP3eEoF3xbs7yijd8"
+        },
+        "href": "https://api.spotify.com/v1/tracks/22WDopP3eEoF3xbs7yijd8",
+        "id": "22WDopP3eEoF3xbs7yijd8",
+        "name": "Ocean (feat. Khalid) - Goja Remix",
+        "uri": "spotify:track:22WDopP3eEoF3xbs7yijd8",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1XQ6XbZ6ZM1V5iEtWlYDeH",
+          "id": "1XQ6XbZ6ZM1V5iEtWlYDeH",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273b800b91af812df0ce0dd2883",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02b800b91af812df0ce0dd2883",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851b800b91af812df0ce0dd2883",
+              "width": 64
+            }
+          ],
+          "name": "Ocean (feat. Khalid)",
+          "release_date": "2018-06-15",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1XQ6XbZ6ZM1V5iEtWlYDeH",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+              },
+              "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+              "id": "6LuN9FCkKOj5PcnpouEgny",
+              "name": "Khalid",
+              "type": "artist",
+              "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1XQ6XbZ6ZM1V5iEtWlYDeH"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6LuN9FCkKOj5PcnpouEgny"
+            },
+            "href": "https://api.spotify.com/v1/artists/6LuN9FCkKOj5PcnpouEgny",
+            "id": "6LuN9FCkKOj5PcnpouEgny",
+            "name": "Khalid",
+            "type": "artist",
+            "uri": "spotify:artist:6LuN9FCkKOj5PcnpouEgny"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 216419,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3nc420PXjTdBV5TN0gCFkS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3nc420PXjTdBV5TN0gCFkS",
+        "id": "3nc420PXjTdBV5TN0gCFkS",
+        "name": "Ocean (feat. Khalid)",
+        "uri": "spotify:track:3nc420PXjTdBV5TN0gCFkS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1XyGfEhJHf3OtvFxg7XgXJ",
+          "id": "1XyGfEhJHf3OtvFxg7XgXJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733a4f75821dcb6d73d757a935",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023a4f75821dcb6d73d757a935",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513a4f75821dcb6d73d757a935",
+              "width": 64
+            }
+          ],
+          "name": "Like I Do (Remixes; Soonvibes Contest)",
+          "release_date": "2018-06-08",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1XyGfEhJHf3OtvFxg7XgXJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1XyGfEhJHf3OtvFxg7XgXJ"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5LYcv0odhsGMWwAqIUzw8Q"
+            },
+            "href": "https://api.spotify.com/v1/artists/5LYcv0odhsGMWwAqIUzw8Q",
+            "id": "5LYcv0odhsGMWwAqIUzw8Q",
+            "name": "Dasko & Agrero",
+            "type": "artist",
+            "uri": "spotify:artist:5LYcv0odhsGMWwAqIUzw8Q"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 178000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/06AkkR7C7oHeQF3LiTUFc2"
+        },
+        "href": "https://api.spotify.com/v1/tracks/06AkkR7C7oHeQF3LiTUFc2",
+        "id": "06AkkR7C7oHeQF3LiTUFc2",
+        "name": "Like I Do - Dasko & Agrero Remix",
+        "uri": "spotify:track:06AkkR7C7oHeQF3LiTUFc2",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1XyGfEhJHf3OtvFxg7XgXJ",
+          "id": "1XyGfEhJHf3OtvFxg7XgXJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733a4f75821dcb6d73d757a935",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023a4f75821dcb6d73d757a935",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513a4f75821dcb6d73d757a935",
+              "width": 64
+            }
+          ],
+          "name": "Like I Do (Remixes; Soonvibes Contest)",
+          "release_date": "2018-06-08",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1XyGfEhJHf3OtvFxg7XgXJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1XyGfEhJHf3OtvFxg7XgXJ"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7795o3nUrbz3kl6KOqHEDA"
+            },
+            "href": "https://api.spotify.com/v1/artists/7795o3nUrbz3kl6KOqHEDA",
+            "id": "7795o3nUrbz3kl6KOqHEDA",
+            "name": "Upsilone",
+            "type": "artist",
+            "uri": "spotify:artist:7795o3nUrbz3kl6KOqHEDA"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 170847,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1RINo28mNyYj4L4vnVvDVS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1RINo28mNyYj4L4vnVvDVS",
+        "id": "1RINo28mNyYj4L4vnVvDVS",
+        "name": "Like I Do - Upsilone Remix",
+        "uri": "spotify:track:1RINo28mNyYj4L4vnVvDVS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1XyGfEhJHf3OtvFxg7XgXJ",
+          "id": "1XyGfEhJHf3OtvFxg7XgXJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733a4f75821dcb6d73d757a935",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023a4f75821dcb6d73d757a935",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513a4f75821dcb6d73d757a935",
+              "width": 64
+            }
+          ],
+          "name": "Like I Do (Remixes; Soonvibes Contest)",
+          "release_date": "2018-06-08",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1XyGfEhJHf3OtvFxg7XgXJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1XyGfEhJHf3OtvFxg7XgXJ"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5IeOVvVjGxaiV46jcf6rlh"
+            },
+            "href": "https://api.spotify.com/v1/artists/5IeOVvVjGxaiV46jcf6rlh",
+            "id": "5IeOVvVjGxaiV46jcf6rlh",
+            "name": "Jumpexx",
+            "type": "artist",
+            "uri": "spotify:artist:5IeOVvVjGxaiV46jcf6rlh"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 247500,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/05Lkts4ESloN7D8L0P5DP9"
+        },
+        "href": "https://api.spotify.com/v1/tracks/05Lkts4ESloN7D8L0P5DP9",
+        "id": "05Lkts4ESloN7D8L0P5DP9",
+        "name": "Like I Do - Jumpexx Remix",
+        "uri": "spotify:track:05Lkts4ESloN7D8L0P5DP9",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1XyGfEhJHf3OtvFxg7XgXJ",
+          "id": "1XyGfEhJHf3OtvFxg7XgXJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733a4f75821dcb6d73d757a935",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023a4f75821dcb6d73d757a935",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513a4f75821dcb6d73d757a935",
+              "width": 64
+            }
+          ],
+          "name": "Like I Do (Remixes; Soonvibes Contest)",
+          "release_date": "2018-06-08",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1XyGfEhJHf3OtvFxg7XgXJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1XyGfEhJHf3OtvFxg7XgXJ"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1ISXjz1BdUF5WoggedkfIm"
+            },
+            "href": "https://api.spotify.com/v1/artists/1ISXjz1BdUF5WoggedkfIm",
+            "id": "1ISXjz1BdUF5WoggedkfIm",
+            "name": "Conor Ross",
+            "type": "artist",
+            "uri": "spotify:artist:1ISXjz1BdUF5WoggedkfIm"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6lmt4U7hMQhnQzqpDJ1Tor"
+            },
+            "href": "https://api.spotify.com/v1/artists/6lmt4U7hMQhnQzqpDJ1Tor",
+            "id": "6lmt4U7hMQhnQzqpDJ1Tor",
+            "name": "Foxa",
+            "type": "artist",
+            "uri": "spotify:artist:6lmt4U7hMQhnQzqpDJ1Tor"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 223024,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/14DvjGlRWdf5SvOFmS0sjD"
+        },
+        "href": "https://api.spotify.com/v1/tracks/14DvjGlRWdf5SvOFmS0sjD",
+        "id": "14DvjGlRWdf5SvOFmS0sjD",
+        "name": "Like I Do - Foxa & Conor Ross Remix",
+        "uri": "spotify:track:14DvjGlRWdf5SvOFmS0sjD",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1XyGfEhJHf3OtvFxg7XgXJ",
+          "id": "1XyGfEhJHf3OtvFxg7XgXJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733a4f75821dcb6d73d757a935",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023a4f75821dcb6d73d757a935",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513a4f75821dcb6d73d757a935",
+              "width": 64
+            }
+          ],
+          "name": "Like I Do (Remixes; Soonvibes Contest)",
+          "release_date": "2018-06-08",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1XyGfEhJHf3OtvFxg7XgXJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1XyGfEhJHf3OtvFxg7XgXJ"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5zQqfkTJNj7rodrMI0UjU5"
+            },
+            "href": "https://api.spotify.com/v1/artists/5zQqfkTJNj7rodrMI0UjU5",
+            "id": "5zQqfkTJNj7rodrMI0UjU5",
+            "name": "Edson Faiolli",
+            "type": "artist",
+            "uri": "spotify:artist:5zQqfkTJNj7rodrMI0UjU5"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 310091,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2gEaU0pIbR6IC1f9iXABtk"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2gEaU0pIbR6IC1f9iXABtk",
+        "id": "2gEaU0pIbR6IC1f9iXABtk",
+        "name": "Like I Do - Edson Faiolli Remix",
+        "uri": "spotify:track:2gEaU0pIbR6IC1f9iXABtk",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/28DX5MHDKHdqLJ4UUHmzve",
+          "id": "28DX5MHDKHdqLJ4UUHmzve",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273180355b7182b2c229efccda4",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02180355b7182b2c229efccda4",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851180355b7182b2c229efccda4",
+              "width": 64
+            }
+          ],
+          "name": "Game Over",
+          "release_date": "2018-04-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:28DX5MHDKHdqLJ4UUHmzve",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0Aemly9h57T2sLKpkNq409"
+              },
+              "href": "https://api.spotify.com/v1/artists/0Aemly9h57T2sLKpkNq409",
+              "id": "0Aemly9h57T2sLKpkNq409",
+              "name": "LOOPERS",
+              "type": "artist",
+              "uri": "spotify:artist:0Aemly9h57T2sLKpkNq409"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/28DX5MHDKHdqLJ4UUHmzve"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0Aemly9h57T2sLKpkNq409"
+            },
+            "href": "https://api.spotify.com/v1/artists/0Aemly9h57T2sLKpkNq409",
+            "id": "0Aemly9h57T2sLKpkNq409",
+            "name": "LOOPERS",
+            "type": "artist",
+            "uri": "spotify:artist:0Aemly9h57T2sLKpkNq409"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 155644,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5Zpe48RJ5Vs1YuFRodYdeS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5Zpe48RJ5Vs1YuFRodYdeS",
+        "id": "5Zpe48RJ5Vs1YuFRodYdeS",
+        "name": "Game Over",
+        "uri": "spotify:track:5Zpe48RJ5Vs1YuFRodYdeS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5oU1ROIHS6IOWnb87GWhqU",
+          "id": "5oU1ROIHS6IOWnb87GWhqU",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273734eb0ed1bd80aeed903f30b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02734eb0ed1bd80aeed903f30b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851734eb0ed1bd80aeed903f30b",
+              "width": 64
+            }
+          ],
+          "name": "Like I Do",
+          "release_date": "2018-02-22",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5oU1ROIHS6IOWnb87GWhqU",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5oU1ROIHS6IOWnb87GWhqU"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 202500,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6RnkFd8Fqqgk1Uni8RgqCQ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6RnkFd8Fqqgk1Uni8RgqCQ",
+        "id": "6RnkFd8Fqqgk1Uni8RgqCQ",
+        "name": "Like I Do",
+        "uri": "spotify:track:6RnkFd8Fqqgk1Uni8RgqCQ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7arUtdMF7AuXh7MBjniqMM",
+          "id": "7arUtdMF7AuXh7MBjniqMM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735a03e27952c4b32a503e370f",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025a03e27952c4b32a503e370f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515a03e27952c4b32a503e370f",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 2]",
+          "release_date": "2018-01-05",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7arUtdMF7AuXh7MBjniqMM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7arUtdMF7AuXh7MBjniqMM"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/78DWNk8gFHU30TGITAgbM7"
+            },
+            "href": "https://api.spotify.com/v1/artists/78DWNk8gFHU30TGITAgbM7",
+            "id": "78DWNk8gFHU30TGITAgbM7",
+            "name": "CMC$",
+            "type": "artist",
+            "uri": "spotify:artist:78DWNk8gFHU30TGITAgbM7"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 166905,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5AXUrzvBrTJKbZjklDnytd"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5AXUrzvBrTJKbZjklDnytd",
+        "id": "5AXUrzvBrTJKbZjklDnytd",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - CMC$ Remix",
+        "uri": "spotify:track:5AXUrzvBrTJKbZjklDnytd",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7arUtdMF7AuXh7MBjniqMM",
+          "id": "7arUtdMF7AuXh7MBjniqMM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735a03e27952c4b32a503e370f",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025a03e27952c4b32a503e370f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515a03e27952c4b32a503e370f",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 2]",
+          "release_date": "2018-01-05",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7arUtdMF7AuXh7MBjniqMM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7arUtdMF7AuXh7MBjniqMM"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3FBxzgzGPs9XUfSYZgG1vX"
+            },
+            "href": "https://api.spotify.com/v1/artists/3FBxzgzGPs9XUfSYZgG1vX",
+            "id": "3FBxzgzGPs9XUfSYZgG1vX",
+            "name": "Codes",
+            "type": "artist",
+            "uri": "spotify:artist:3FBxzgzGPs9XUfSYZgG1vX"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 241799,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0n2EGW8WSzLQESjxEyN2iu"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0n2EGW8WSzLQESjxEyN2iu",
+        "id": "0n2EGW8WSzLQESjxEyN2iu",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - Codes Remix",
+        "uri": "spotify:track:0n2EGW8WSzLQESjxEyN2iu",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7arUtdMF7AuXh7MBjniqMM",
+          "id": "7arUtdMF7AuXh7MBjniqMM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735a03e27952c4b32a503e370f",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025a03e27952c4b32a503e370f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515a03e27952c4b32a503e370f",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 2]",
+          "release_date": "2018-01-05",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7arUtdMF7AuXh7MBjniqMM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7arUtdMF7AuXh7MBjniqMM"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2XiiUuK68XNdHaHOAF5hnT"
+            },
+            "href": "https://api.spotify.com/v1/artists/2XiiUuK68XNdHaHOAF5hnT",
+            "id": "2XiiUuK68XNdHaHOAF5hnT",
+            "name": "Curbi",
+            "type": "artist",
+            "uri": "spotify:artist:2XiiUuK68XNdHaHOAF5hnT"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 209139,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6oISPN6Clrwt75JFiQF7aO"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6oISPN6Clrwt75JFiQF7aO",
+        "id": "6oISPN6Clrwt75JFiQF7aO",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - Curbi Remix",
+        "uri": "spotify:track:6oISPN6Clrwt75JFiQF7aO",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7arUtdMF7AuXh7MBjniqMM",
+          "id": "7arUtdMF7AuXh7MBjniqMM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735a03e27952c4b32a503e370f",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025a03e27952c4b32a503e370f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515a03e27952c4b32a503e370f",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 2]",
+          "release_date": "2018-01-05",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7arUtdMF7AuXh7MBjniqMM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7arUtdMF7AuXh7MBjniqMM"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3GTclJDhrh2C4k8VveMhM6"
+            },
+            "href": "https://api.spotify.com/v1/artists/3GTclJDhrh2C4k8VveMhM6",
+            "id": "3GTclJDhrh2C4k8VveMhM6",
+            "name": "Bad Decisions",
+            "type": "artist",
+            "uri": "spotify:artist:3GTclJDhrh2C4k8VveMhM6"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 246400,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0rNg50D2j2Aq58V3jqdEuu"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0rNg50D2j2Aq58V3jqdEuu",
+        "id": "0rNg50D2j2Aq58V3jqdEuu",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - Bad Decisions Remix",
+        "uri": "spotify:track:0rNg50D2j2Aq58V3jqdEuu",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7arUtdMF7AuXh7MBjniqMM",
+          "id": "7arUtdMF7AuXh7MBjniqMM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735a03e27952c4b32a503e370f",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025a03e27952c4b32a503e370f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515a03e27952c4b32a503e370f",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 2]",
+          "release_date": "2018-01-05",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7arUtdMF7AuXh7MBjniqMM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7arUtdMF7AuXh7MBjniqMM"
+          },
+          "total_tracks": 5
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/70c48bioArCGTsN9pH04NT"
+            },
+            "href": "https://api.spotify.com/v1/artists/70c48bioArCGTsN9pH04NT",
+            "id": "70c48bioArCGTsN9pH04NT",
+            "name": "Osrin",
+            "type": "artist",
+            "uri": "spotify:artist:70c48bioArCGTsN9pH04NT"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 200599,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5BOSoyflOWt7LB1o1t5iOv"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5BOSoyflOWt7LB1o1t5iOv",
+        "id": "5BOSoyflOWt7LB1o1t5iOv",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - Osrin Remix",
+        "uri": "spotify:track:5BOSoyflOWt7LB1o1t5iOv",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7sdcEE59A6EGhriYpDSTTE",
+          "id": "7sdcEE59A6EGhriYpDSTTE",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735056667ee73133264268d712",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025056667ee73133264268d712",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515056667ee73133264268d712",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 1]",
+          "release_date": "2017-12-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7sdcEE59A6EGhriYpDSTTE",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7sdcEE59A6EGhriYpDSTTE"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/26JVnujQQ3lEML8t9p3X1J"
+            },
+            "href": "https://api.spotify.com/v1/artists/26JVnujQQ3lEML8t9p3X1J",
+            "id": "26JVnujQQ3lEML8t9p3X1J",
+            "name": "Blinders",
+            "type": "artist",
+            "uri": "spotify:artist:26JVnujQQ3lEML8t9p3X1J"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 196190,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/033eAdPpnmBbgfLvbLBih0"
+        },
+        "href": "https://api.spotify.com/v1/tracks/033eAdPpnmBbgfLvbLBih0",
+        "id": "033eAdPpnmBbgfLvbLBih0",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - Blinders Remix",
+        "uri": "spotify:track:033eAdPpnmBbgfLvbLBih0",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7sdcEE59A6EGhriYpDSTTE",
+          "id": "7sdcEE59A6EGhriYpDSTTE",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735056667ee73133264268d712",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025056667ee73133264268d712",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515056667ee73133264268d712",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 1]",
+          "release_date": "2017-12-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7sdcEE59A6EGhriYpDSTTE",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7sdcEE59A6EGhriYpDSTTE"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+            },
+            "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+            "id": "5ChF3i92IPZHduM7jN3dpg",
+            "name": "Nicky Romero",
+            "type": "artist",
+            "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 342857,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7J7D2Ezp32LxlYuNTZX48n"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7J7D2Ezp32LxlYuNTZX48n",
+        "id": "7J7D2Ezp32LxlYuNTZX48n",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - Nicky Romero Remix",
+        "uri": "spotify:track:7J7D2Ezp32LxlYuNTZX48n",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7sdcEE59A6EGhriYpDSTTE",
+          "id": "7sdcEE59A6EGhriYpDSTTE",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735056667ee73133264268d712",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025056667ee73133264268d712",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515056667ee73133264268d712",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 1]",
+          "release_date": "2017-12-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7sdcEE59A6EGhriYpDSTTE",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7sdcEE59A6EGhriYpDSTTE"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6eZxwKfQWK4d5sLOlauR1Y"
+            },
+            "href": "https://api.spotify.com/v1/artists/6eZxwKfQWK4d5sLOlauR1Y",
+            "id": "6eZxwKfQWK4d5sLOlauR1Y",
+            "name": "BLR",
+            "type": "artist",
+            "uri": "spotify:artist:6eZxwKfQWK4d5sLOlauR1Y"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 183414,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/07hSIkFnDpOhpb46h475Ss"
+        },
+        "href": "https://api.spotify.com/v1/tracks/07hSIkFnDpOhpb46h475Ss",
+        "id": "07hSIkFnDpOhpb46h475Ss",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - BLR Remix",
+        "uri": "spotify:track:07hSIkFnDpOhpb46h475Ss",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7sdcEE59A6EGhriYpDSTTE",
+          "id": "7sdcEE59A6EGhriYpDSTTE",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735056667ee73133264268d712",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025056667ee73133264268d712",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515056667ee73133264268d712",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 1]",
+          "release_date": "2017-12-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7sdcEE59A6EGhriYpDSTTE",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7sdcEE59A6EGhriYpDSTTE"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/32Aw9aJJoXXC1Vn3zqzJbQ"
+            },
+            "href": "https://api.spotify.com/v1/artists/32Aw9aJJoXXC1Vn3zqzJbQ",
+            "id": "32Aw9aJJoXXC1Vn3zqzJbQ",
+            "name": "TV Noise",
+            "type": "artist",
+            "uri": "spotify:artist:32Aw9aJJoXXC1Vn3zqzJbQ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 180000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0iX9BV34AHBpdfEMgWm5mU"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0iX9BV34AHBpdfEMgWm5mU",
+        "id": "0iX9BV34AHBpdfEMgWm5mU",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - TV Noise Remix",
+        "uri": "spotify:track:0iX9BV34AHBpdfEMgWm5mU",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7sdcEE59A6EGhriYpDSTTE",
+          "id": "7sdcEE59A6EGhriYpDSTTE",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735056667ee73133264268d712",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025056667ee73133264268d712",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515056667ee73133264268d712",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 1]",
+          "release_date": "2017-12-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7sdcEE59A6EGhriYpDSTTE",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7sdcEE59A6EGhriYpDSTTE"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2IQIEHvL14Tj7vOKHbIMMj"
+            },
+            "href": "https://api.spotify.com/v1/artists/2IQIEHvL14Tj7vOKHbIMMj",
+            "id": "2IQIEHvL14Tj7vOKHbIMMj",
+            "name": "CLiQ",
+            "type": "artist",
+            "uri": "spotify:artist:2IQIEHvL14Tj7vOKHbIMMj"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 213359,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7BLZP3Q291G2iVKKgVRDyj"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7BLZP3Q291G2iVKKgVRDyj",
+        "id": "7BLZP3Q291G2iVKKgVRDyj",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - CLiQ Remix",
+        "uri": "spotify:track:7BLZP3Q291G2iVKKgVRDyj",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7sdcEE59A6EGhriYpDSTTE",
+          "id": "7sdcEE59A6EGhriYpDSTTE",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2735056667ee73133264268d712",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e025056667ee73133264268d712",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048515056667ee73133264268d712",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya) [Remixes Vol. 1]",
+          "release_date": "2017-12-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7sdcEE59A6EGhriYpDSTTE",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7sdcEE59A6EGhriYpDSTTE"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2IQIEHvL14Tj7vOKHbIMMj"
+            },
+            "href": "https://api.spotify.com/v1/artists/2IQIEHvL14Tj7vOKHbIMMj",
+            "id": "2IQIEHvL14Tj7vOKHbIMMj",
+            "name": "CLiQ",
+            "type": "artist",
+            "uri": "spotify:artist:2IQIEHvL14Tj7vOKHbIMMj"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 6,
+        "duration_ms": 344709,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7aH3sZ85qQshN0H5ntgvnO"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7aH3sZ85qQshN0H5ntgvnO",
+        "id": "7aH3sZ85qQshN0H5ntgvnO",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya) - CLiQ Dub Remix",
+        "uri": "spotify:track:7aH3sZ85qQshN0H5ntgvnO",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3jMnO9ehAlTTCxNeVMu1zY",
+          "id": "3jMnO9ehAlTTCxNeVMu1zY",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273f9ad0c234f7ea5d10a314cb1",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02f9ad0c234f7ea5d10a314cb1",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851f9ad0c234f7ea5d10a314cb1",
+              "width": 64
+            }
+          ],
+          "name": "So Far Away (feat. Jamie Scott & Romy Dya)",
+          "release_date": "2017-12-01",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3jMnO9ehAlTTCxNeVMu1zY",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3jMnO9ehAlTTCxNeVMu1zY"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+            "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+            "name": "David Guetta",
+            "type": "artist",
+            "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/29QbBR0oTzA7A0kiOzrbbr"
+            },
+            "href": "https://api.spotify.com/v1/artists/29QbBR0oTzA7A0kiOzrbbr",
+            "id": "29QbBR0oTzA7A0kiOzrbbr",
+            "name": "Jamie Scott",
+            "type": "artist",
+            "uri": "spotify:artist:29QbBR0oTzA7A0kiOzrbbr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gWzmnHTLNXz5CjOc0wAuK"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gWzmnHTLNXz5CjOc0wAuK",
+            "id": "5gWzmnHTLNXz5CjOc0wAuK",
+            "name": "Romy Dya",
+            "type": "artist",
+            "uri": "spotify:artist:5gWzmnHTLNXz5CjOc0wAuK"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 183636,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0OlnLZY4cmQzT6ZGttvWBM"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0OlnLZY4cmQzT6ZGttvWBM",
+        "id": "0OlnLZY4cmQzT6ZGttvWBM",
+        "name": "So Far Away (feat. Jamie Scott & Romy Dya)",
+        "uri": "spotify:track:0OlnLZY4cmQzT6ZGttvWBM",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7zFHC5p1ylePX7dNxln5iJ",
+          "id": "7zFHC5p1ylePX7dNxln5iJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273fc7c5d5c997a0440dcac1174",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02fc7c5d5c997a0440dcac1174",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851fc7c5d5c997a0440dcac1174",
+              "width": 64
+            }
+          ],
+          "name": "Forever",
+          "release_date": "2017-10-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7zFHC5p1ylePX7dNxln5iJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7zFHC5p1ylePX7dNxln5iJ"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+            },
+            "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+            "id": "2QMCcKIPHnjQaPPgoEst88",
+            "name": "Matisse & Sadko",
+            "type": "artist",
+            "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 218437,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5EwwwdsQfKI8ZnFG93j5Zu"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5EwwwdsQfKI8ZnFG93j5Zu",
+        "id": "5EwwwdsQfKI8ZnFG93j5Zu",
+        "name": "Forever",
+        "uri": "spotify:track:5EwwwdsQfKI8ZnFG93j5Zu",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2GNtmwsvrBPWHl8aaOXJMp",
+          "id": "2GNtmwsvrBPWHl8aaOXJMp",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d8f343d6f3763bc9850dffe9",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d8f343d6f3763bc9850dffe9",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d8f343d6f3763bc9850dffe9",
+              "width": 64
+            }
+          ],
+          "name": "Pizza",
+          "release_date": "2017-08-25",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2GNtmwsvrBPWHl8aaOXJMp",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2GNtmwsvrBPWHl8aaOXJMp"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 255102,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5oAgI7Pzg6vxuKrfapg3Pi"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5oAgI7Pzg6vxuKrfapg3Pi",
+        "id": "5oAgI7Pzg6vxuKrfapg3Pi",
+        "name": "Pizza",
+        "uri": "spotify:track:5oAgI7Pzg6vxuKrfapg3Pi",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2CdO0qRrFnQnVNiT8Xjb2U"
+            },
+            "href": "https://api.spotify.com/v1/artists/2CdO0qRrFnQnVNiT8Xjb2U",
+            "id": "2CdO0qRrFnQnVNiT8Xjb2U",
+            "name": "Araatan",
+            "type": "artist",
+            "uri": "spotify:artist:2CdO0qRrFnQnVNiT8Xjb2U"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 169723,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3QNvNS6T7nKCQDW4WLl8mC"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3QNvNS6T7nKCQDW4WLl8mC",
+        "id": "3QNvNS6T7nKCQDW4WLl8mC",
+        "name": "There For You - Araatan Remix",
+        "uri": "spotify:track:3QNvNS6T7nKCQDW4WLl8mC",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1GcKPo3HglflWJSV683pHx"
+            },
+            "href": "https://api.spotify.com/v1/artists/1GcKPo3HglflWJSV683pHx",
+            "id": "1GcKPo3HglflWJSV683pHx",
+            "name": "Bali Bandits",
+            "type": "artist",
+            "uri": "spotify:artist:1GcKPo3HglflWJSV683pHx"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 192380,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5onhXSEjtfXVe9mnjQIPzN"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5onhXSEjtfXVe9mnjQIPzN",
+        "id": "5onhXSEjtfXVe9mnjQIPzN",
+        "name": "There For You - Bali Bandits Remix",
+        "uri": "spotify:track:5onhXSEjtfXVe9mnjQIPzN",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5vQfv3s2Z2SRdPZKr82ABw"
+            },
+            "href": "https://api.spotify.com/v1/artists/5vQfv3s2Z2SRdPZKr82ABw",
+            "id": "5vQfv3s2Z2SRdPZKr82ABw",
+            "name": "Dzeko",
+            "type": "artist",
+            "uri": "spotify:artist:5vQfv3s2Z2SRdPZKr82ABw"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 159047,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7qDV8EUMjj5sJdholWKUqk"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7qDV8EUMjj5sJdholWKUqk",
+        "id": "7qDV8EUMjj5sJdholWKUqk",
+        "name": "There For You - Dzeko Remix",
+        "uri": "spotify:track:7qDV8EUMjj5sJdholWKUqk",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1eOOXqRHILTxqrEUAYyQU0"
+            },
+            "href": "https://api.spotify.com/v1/artists/1eOOXqRHILTxqrEUAYyQU0",
+            "id": "1eOOXqRHILTxqrEUAYyQU0",
+            "name": "Bart B More",
+            "type": "artist",
+            "uri": "spotify:artist:1eOOXqRHILTxqrEUAYyQU0"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 174720,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0mHRvRW06RLS0NsldsGwDd"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0mHRvRW06RLS0NsldsGwDd",
+        "id": "0mHRvRW06RLS0NsldsGwDd",
+        "name": "There For You - Bart B More Remix",
+        "uri": "spotify:track:0mHRvRW06RLS0NsldsGwDd",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+            },
+            "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+            "id": "2vUCVkeZjzDcaoX4gagHdV",
+            "name": "Julian Jordan",
+            "type": "artist",
+            "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 183647,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5QbBPup3fiUciyTYQesNHs"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5QbBPup3fiUciyTYQesNHs",
+        "id": "5QbBPup3fiUciyTYQesNHs",
+        "name": "There For You - Julian Jordan Remix",
+        "uri": "spotify:track:5QbBPup3fiUciyTYQesNHs",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4gJCFxvqKc43Ifk0UIBB42"
+            },
+            "href": "https://api.spotify.com/v1/artists/4gJCFxvqKc43Ifk0UIBB42",
+            "id": "4gJCFxvqKc43Ifk0UIBB42",
+            "name": "Madison Mars",
+            "type": "artist",
+            "uri": "spotify:artist:4gJCFxvqKc43Ifk0UIBB42"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 6,
+        "duration_ms": 175000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5K3NDUPkLe46b5DRMt2RNJ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5K3NDUPkLe46b5DRMt2RNJ",
+        "id": "5K3NDUPkLe46b5DRMt2RNJ",
+        "name": "There For You - Madison Mars Remix",
+        "uri": "spotify:track:5K3NDUPkLe46b5DRMt2RNJ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3Dkul6nShja7zaggvl66rB"
+            },
+            "href": "https://api.spotify.com/v1/artists/3Dkul6nShja7zaggvl66rB",
+            "id": "3Dkul6nShja7zaggvl66rB",
+            "name": "Kohen",
+            "type": "artist",
+            "uri": "spotify:artist:3Dkul6nShja7zaggvl66rB"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/28uJnu5EsrGml2tBd7y8ts"
+            },
+            "href": "https://api.spotify.com/v1/artists/28uJnu5EsrGml2tBd7y8ts",
+            "id": "28uJnu5EsrGml2tBd7y8ts",
+            "name": "Vintage Culture",
+            "type": "artist",
+            "uri": "spotify:artist:28uJnu5EsrGml2tBd7y8ts"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 7,
+        "duration_ms": 205028,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2n5yg76iEf4ShjPm7vK6zX"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2n5yg76iEf4ShjPm7vK6zX",
+        "id": "2n5yg76iEf4ShjPm7vK6zX",
+        "name": "There For You - Vintage Culture & Kohen Remix",
+        "uri": "spotify:track:2n5yg76iEf4ShjPm7vK6zX",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2qPxiZiD34NtmokWN6RoP2"
+            },
+            "href": "https://api.spotify.com/v1/artists/2qPxiZiD34NtmokWN6RoP2",
+            "id": "2qPxiZiD34NtmokWN6RoP2",
+            "name": "King Topher",
+            "type": "artist",
+            "uri": "spotify:artist:2qPxiZiD34NtmokWN6RoP2"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 8,
+        "duration_ms": 236129,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1A68wwIOaUYNFLqYD8sm2n"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1A68wwIOaUYNFLqYD8sm2n",
+        "id": "1A68wwIOaUYNFLqYD8sm2n",
+        "name": "There For You - King Topher Remix",
+        "uri": "spotify:track:1A68wwIOaUYNFLqYD8sm2n",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/670UISOh9XV1zlq5z5IfoY"
+            },
+            "href": "https://api.spotify.com/v1/artists/670UISOh9XV1zlq5z5IfoY",
+            "id": "670UISOh9XV1zlq5z5IfoY",
+            "name": "GOLDHOUSE",
+            "type": "artist",
+            "uri": "spotify:artist:670UISOh9XV1zlq5z5IfoY"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 9,
+        "duration_ms": 183530,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/63LdoxgPG1bY3WnooMUp0J"
+        },
+        "href": "https://api.spotify.com/v1/tracks/63LdoxgPG1bY3WnooMUp0J",
+        "id": "63LdoxgPG1bY3WnooMUp0J",
+        "name": "There For You - Goldhouse Remix",
+        "uri": "spotify:track:63LdoxgPG1bY3WnooMUp0J",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IHsD0sttucHrX8b32Vcab"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IHsD0sttucHrX8b32Vcab",
+            "id": "3IHsD0sttucHrX8b32Vcab",
+            "name": "BROHUG",
+            "type": "artist",
+            "uri": "spotify:artist:3IHsD0sttucHrX8b32Vcab"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 10,
+        "duration_ms": 203520,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1DeuU4vbb30Djy2veBAxHL"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1DeuU4vbb30Djy2veBAxHL",
+        "id": "1DeuU4vbb30Djy2veBAxHL",
+        "name": "There For You - Brohug Remix",
+        "uri": "spotify:track:1DeuU4vbb30Djy2veBAxHL",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4Zv449cAssgslcvInvc0wa"
+            },
+            "href": "https://api.spotify.com/v1/artists/4Zv449cAssgslcvInvc0wa",
+            "id": "4Zv449cAssgslcvInvc0wa",
+            "name": "LIONE",
+            "type": "artist",
+            "uri": "spotify:artist:4Zv449cAssgslcvInvc0wa"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 11,
+        "duration_ms": 275942,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/41RjRFL8MxWdlMkJ2znnOM"
+        },
+        "href": "https://api.spotify.com/v1/tracks/41RjRFL8MxWdlMkJ2znnOM",
+        "id": "41RjRFL8MxWdlMkJ2znnOM",
+        "name": "There For You - Lione Remix",
+        "uri": "spotify:track:41RjRFL8MxWdlMkJ2znnOM",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2XXJOpnawvArFxXTu2A1VM",
+          "id": "2XXJOpnawvArFxXTu2A1VM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ca2c3fbe32ce1b4946175b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ca2c3fbe32ce1b4946175b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ca2c3fbe32ce1b4946175b",
+              "width": 64
+            }
+          ],
+          "name": "There For You: The Remixes",
+          "release_date": "2017-08-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2XXJOpnawvArFxXTu2A1VM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2XXJOpnawvArFxXTu2A1VM"
+          },
+          "total_tracks": 12
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6v6tycmzJDLrgOXTj7mbT9"
+            },
+            "href": "https://api.spotify.com/v1/artists/6v6tycmzJDLrgOXTj7mbT9",
+            "id": "6v6tycmzJDLrgOXTj7mbT9",
+            "name": "Lontalius",
+            "type": "artist",
+            "uri": "spotify:artist:6v6tycmzJDLrgOXTj7mbT9"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 12,
+        "duration_ms": 226626,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0SMXGKhlgFJqoKlsAY7D8b"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0SMXGKhlgFJqoKlsAY7D8b",
+        "id": "0SMXGKhlgFJqoKlsAY7D8b",
+        "name": "There For You - Lontalius Remix",
+        "uri": "spotify:track:0SMXGKhlgFJqoKlsAY7D8b",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0OK35duHpTPnvqya2d4pnn",
+          "id": "0OK35duHpTPnvqya2d4pnn",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733e102965fc5b282d76cf1c2c",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023e102965fc5b282d76cf1c2c",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513e102965fc5b282d76cf1c2c",
+              "width": 64
+            }
+          ],
+          "name": "There for You",
+          "release_date": "2017-05-26",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0OK35duHpTPnvqya2d4pnn",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+              },
+              "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+              "id": "3WGpXCj9YhhfX11TToZcXP",
+              "name": "Troye Sivan",
+              "type": "artist",
+              "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0OK35duHpTPnvqya2d4pnn"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+            "id": "3WGpXCj9YhhfX11TToZcXP",
+            "name": "Troye Sivan",
+            "type": "artist",
+            "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 221904,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6jA8HL9i4QGzsj6fjoxp8Y"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6jA8HL9i4QGzsj6fjoxp8Y",
+        "id": "6jA8HL9i4QGzsj6fjoxp8Y",
+        "name": "There for You",
+        "uri": "spotify:track:6jA8HL9i4QGzsj6fjoxp8Y",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7bhogovOiLN8d5QEKltWyc",
+          "id": "7bhogovOiLN8d5QEKltWyc",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2739db4fe84ba3acddc3cc46831",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e029db4fe84ba3acddc3cc46831",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048519db4fe84ba3acddc3cc46831",
+              "width": 64
+            }
+          ],
+          "name": "Byte",
+          "release_date": "2017-04-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7bhogovOiLN8d5QEKltWyc",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7bhogovOiLN8d5QEKltWyc"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 285089,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/20hsdn8oITBsuWNLhzr5eh"
+        },
+        "href": "https://api.spotify.com/v1/tracks/20hsdn8oITBsuWNLhzr5eh",
+        "id": "20hsdn8oITBsuWNLhzr5eh",
+        "name": "Byte",
+        "uri": "spotify:track:20hsdn8oITBsuWNLhzr5eh",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6YGs9QbzBuoXWWeJ2rcSBY",
+          "id": "6YGs9QbzBuoXWWeJ2rcSBY",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27397ba84caf9319492cbc986be",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0297ba84caf9319492cbc986be",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485197ba84caf9319492cbc986be",
+              "width": 64
+            }
+          ],
+          "name": "Scared to Be Lonely (Acoustic Version)",
+          "release_date": "2017-04-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6YGs9QbzBuoXWWeJ2rcSBY",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6YGs9QbzBuoXWWeJ2rcSBY"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 257357,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/29CjkGjZnDVdJsfbRoNOGJ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/29CjkGjZnDVdJsfbRoNOGJ",
+        "id": "29CjkGjZnDVdJsfbRoNOGJ",
+        "name": "Scared to Be Lonely - Acoustic Version",
+        "uri": "spotify:track:29CjkGjZnDVdJsfbRoNOGJ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5jTkDSrXEBAowWeHpsA1a2",
+          "id": "5jTkDSrXEBAowWeHpsA1a2",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2737e0a839515ecac4f7d8c10ea",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e027e0a839515ecac4f7d8c10ea",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048517e0a839515ecac4f7d8c10ea",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 2",
+          "release_date": "2017-03-24",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5jTkDSrXEBAowWeHpsA1a2",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5jTkDSrXEBAowWeHpsA1a2"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Bo8Afb2Qbjs4x6kJHyjle"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Bo8Afb2Qbjs4x6kJHyjle",
+            "id": "1Bo8Afb2Qbjs4x6kJHyjle",
+            "name": "Gigamesh",
+            "type": "artist",
+            "uri": "spotify:artist:1Bo8Afb2Qbjs4x6kJHyjle"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 229322,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0g0kGJsGycdO8QNnu83rDB"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0g0kGJsGycdO8QNnu83rDB",
+        "id": "0g0kGJsGycdO8QNnu83rDB",
+        "name": "Scared To Be Lonely - Gigamesh Remix",
+        "uri": "spotify:track:0g0kGJsGycdO8QNnu83rDB",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5jTkDSrXEBAowWeHpsA1a2",
+          "id": "5jTkDSrXEBAowWeHpsA1a2",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2737e0a839515ecac4f7d8c10ea",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e027e0a839515ecac4f7d8c10ea",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048517e0a839515ecac4f7d8c10ea",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 2",
+          "release_date": "2017-03-24",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5jTkDSrXEBAowWeHpsA1a2",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5jTkDSrXEBAowWeHpsA1a2"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/62vbsDRAq0qHdezaCOzB0T"
+            },
+            "href": "https://api.spotify.com/v1/artists/62vbsDRAq0qHdezaCOzB0T",
+            "id": "62vbsDRAq0qHdezaCOzB0T",
+            "name": "Medasin",
+            "type": "artist",
+            "uri": "spotify:artist:62vbsDRAq0qHdezaCOzB0T"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 212026,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2NRAc1d87vKn0OHK5J73gM"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2NRAc1d87vKn0OHK5J73gM",
+        "id": "2NRAc1d87vKn0OHK5J73gM",
+        "name": "Scared To Be Lonely - Medasin Remix",
+        "uri": "spotify:track:2NRAc1d87vKn0OHK5J73gM",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5jTkDSrXEBAowWeHpsA1a2",
+          "id": "5jTkDSrXEBAowWeHpsA1a2",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2737e0a839515ecac4f7d8c10ea",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e027e0a839515ecac4f7d8c10ea",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048517e0a839515ecac4f7d8c10ea",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 2",
+          "release_date": "2017-03-24",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5jTkDSrXEBAowWeHpsA1a2",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5jTkDSrXEBAowWeHpsA1a2"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6t1gpxYbY8OlLA7D2RiikQ"
+            },
+            "href": "https://api.spotify.com/v1/artists/6t1gpxYbY8OlLA7D2RiikQ",
+            "id": "6t1gpxYbY8OlLA7D2RiikQ",
+            "name": "Loud Luxury",
+            "type": "artist",
+            "uri": "spotify:artist:6t1gpxYbY8OlLA7D2RiikQ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 207884,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/408G7co3LC8uM5pMTldO4X"
+        },
+        "href": "https://api.spotify.com/v1/tracks/408G7co3LC8uM5pMTldO4X",
+        "id": "408G7co3LC8uM5pMTldO4X",
+        "name": "Scared to Be Lonely - Loud Luxury Remix",
+        "uri": "spotify:track:408G7co3LC8uM5pMTldO4X",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5jTkDSrXEBAowWeHpsA1a2",
+          "id": "5jTkDSrXEBAowWeHpsA1a2",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2737e0a839515ecac4f7d8c10ea",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e027e0a839515ecac4f7d8c10ea",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048517e0a839515ecac4f7d8c10ea",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 2",
+          "release_date": "2017-03-24",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5jTkDSrXEBAowWeHpsA1a2",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5jTkDSrXEBAowWeHpsA1a2"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1BAdSa5cdtCNLbvT7gWmtJ"
+            },
+            "href": "https://api.spotify.com/v1/artists/1BAdSa5cdtCNLbvT7gWmtJ",
+            "id": "1BAdSa5cdtCNLbvT7gWmtJ",
+            "name": "Conro",
+            "type": "artist",
+            "uri": "spotify:artist:1BAdSa5cdtCNLbvT7gWmtJ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 202838,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5qEK1dvlPMpOYZTBFPGGPV"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5qEK1dvlPMpOYZTBFPGGPV",
+        "id": "5qEK1dvlPMpOYZTBFPGGPV",
+        "name": "Scared To Be Lonely - Conro Remix",
+        "uri": "spotify:track:5qEK1dvlPMpOYZTBFPGGPV",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5jTkDSrXEBAowWeHpsA1a2",
+          "id": "5jTkDSrXEBAowWeHpsA1a2",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2737e0a839515ecac4f7d8c10ea",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e027e0a839515ecac4f7d8c10ea",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048517e0a839515ecac4f7d8c10ea",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 2",
+          "release_date": "2017-03-24",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5jTkDSrXEBAowWeHpsA1a2",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5jTkDSrXEBAowWeHpsA1a2"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0Aemly9h57T2sLKpkNq409"
+            },
+            "href": "https://api.spotify.com/v1/artists/0Aemly9h57T2sLKpkNq409",
+            "id": "0Aemly9h57T2sLKpkNq409",
+            "name": "LOOPERS",
+            "type": "artist",
+            "uri": "spotify:artist:0Aemly9h57T2sLKpkNq409"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 251274,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/590BSKBR5povyuY6GPq1T3"
+        },
+        "href": "https://api.spotify.com/v1/tracks/590BSKBR5povyuY6GPq1T3",
+        "id": "590BSKBR5povyuY6GPq1T3",
+        "name": "Scared To Be Lonely - LOOPERS Remix",
+        "uri": "spotify:track:590BSKBR5povyuY6GPq1T3",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5jTkDSrXEBAowWeHpsA1a2",
+          "id": "5jTkDSrXEBAowWeHpsA1a2",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2737e0a839515ecac4f7d8c10ea",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e027e0a839515ecac4f7d8c10ea",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048517e0a839515ecac4f7d8c10ea",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 2",
+          "release_date": "2017-03-24",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5jTkDSrXEBAowWeHpsA1a2",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5jTkDSrXEBAowWeHpsA1a2"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1kvPwRRVHcVdA8YY7RHmoz"
+            },
+            "href": "https://api.spotify.com/v1/artists/1kvPwRRVHcVdA8YY7RHmoz",
+            "id": "1kvPwRRVHcVdA8YY7RHmoz",
+            "name": "Joe Mason",
+            "type": "artist",
+            "uri": "spotify:artist:1kvPwRRVHcVdA8YY7RHmoz"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 6,
+        "duration_ms": 207857,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/65AFE1G38tEiav9i5j7gbJ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/65AFE1G38tEiav9i5j7gbJ",
+        "id": "65AFE1G38tEiav9i5j7gbJ",
+        "name": "Scared To Be Lonely - Joe Mason Remix",
+        "uri": "spotify:track:65AFE1G38tEiav9i5j7gbJ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5dwSRV6U5oyxplujp17RQQ",
+          "id": "5dwSRV6U5oyxplujp17RQQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731581c450d87241a23fb057e6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021581c450d87241a23fb057e6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511581c450d87241a23fb057e6",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 1",
+          "release_date": "2017-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dwSRV6U5oyxplujp17RQQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dwSRV6U5oyxplujp17RQQ"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+            },
+            "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+            "id": "4mHAu7NX2UNsnGXjviBD9e",
+            "name": "Brooks",
+            "type": "artist",
+            "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 200624,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/389MC596K4IN35zaHAyuYz"
+        },
+        "href": "https://api.spotify.com/v1/tracks/389MC596K4IN35zaHAyuYz",
+        "id": "389MC596K4IN35zaHAyuYz",
+        "name": "Scared To Be Lonely - Brooks Remix",
+        "uri": "spotify:track:389MC596K4IN35zaHAyuYz",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5dwSRV6U5oyxplujp17RQQ",
+          "id": "5dwSRV6U5oyxplujp17RQQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731581c450d87241a23fb057e6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021581c450d87241a23fb057e6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511581c450d87241a23fb057e6",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 1",
+          "release_date": "2017-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dwSRV6U5oyxplujp17RQQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dwSRV6U5oyxplujp17RQQ"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+            },
+            "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+            "id": "3XINWZaloea97SIRiyTJxX",
+            "name": "DubVision",
+            "type": "artist",
+            "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 190866,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5pOCxpmhVPYmJqny2LWsDT"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5pOCxpmhVPYmJqny2LWsDT",
+        "id": "5pOCxpmhVPYmJqny2LWsDT",
+        "name": "Scared To Be Lonely - DubVision Remix",
+        "uri": "spotify:track:5pOCxpmhVPYmJqny2LWsDT",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5dwSRV6U5oyxplujp17RQQ",
+          "id": "5dwSRV6U5oyxplujp17RQQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731581c450d87241a23fb057e6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021581c450d87241a23fb057e6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511581c450d87241a23fb057e6",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 1",
+          "release_date": "2017-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dwSRV6U5oyxplujp17RQQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dwSRV6U5oyxplujp17RQQ"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0bMKf3lIYR9GaNTdFKkTOr"
+            },
+            "href": "https://api.spotify.com/v1/artists/0bMKf3lIYR9GaNTdFKkTOr",
+            "id": "0bMKf3lIYR9GaNTdFKkTOr",
+            "name": "Zonderling",
+            "type": "artist",
+            "uri": "spotify:artist:0bMKf3lIYR9GaNTdFKkTOr"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 234761,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5C1AIWDr6lIQrYvbc5UV00"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5C1AIWDr6lIQrYvbc5UV00",
+        "id": "5C1AIWDr6lIQrYvbc5UV00",
+        "name": "Scared To Be Lonely - Zonderling Remix",
+        "uri": "spotify:track:5C1AIWDr6lIQrYvbc5UV00",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5dwSRV6U5oyxplujp17RQQ",
+          "id": "5dwSRV6U5oyxplujp17RQQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731581c450d87241a23fb057e6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021581c450d87241a23fb057e6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511581c450d87241a23fb057e6",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 1",
+          "release_date": "2017-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dwSRV6U5oyxplujp17RQQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dwSRV6U5oyxplujp17RQQ"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/629Fs7UJp6tWqOYZi8t8ET"
+            },
+            "href": "https://api.spotify.com/v1/artists/629Fs7UJp6tWqOYZi8t8ET",
+            "id": "629Fs7UJp6tWqOYZi8t8ET",
+            "name": "Alpharock",
+            "type": "artist",
+            "uri": "spotify:artist:629Fs7UJp6tWqOYZi8t8ET"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 235582,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/23YeGkxsp3TfYBiq24DzVF"
+        },
+        "href": "https://api.spotify.com/v1/tracks/23YeGkxsp3TfYBiq24DzVF",
+        "id": "23YeGkxsp3TfYBiq24DzVF",
+        "name": "Scared To Be Lonely - Alpharock Remix",
+        "uri": "spotify:track:23YeGkxsp3TfYBiq24DzVF",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5dwSRV6U5oyxplujp17RQQ",
+          "id": "5dwSRV6U5oyxplujp17RQQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731581c450d87241a23fb057e6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021581c450d87241a23fb057e6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511581c450d87241a23fb057e6",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 1",
+          "release_date": "2017-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dwSRV6U5oyxplujp17RQQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dwSRV6U5oyxplujp17RQQ"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/11chB4Th19iMA7j65oGMk1"
+            },
+            "href": "https://api.spotify.com/v1/artists/11chB4Th19iMA7j65oGMk1",
+            "id": "11chB4Th19iMA7j65oGMk1",
+            "name": "Funkin Matt",
+            "type": "artist",
+            "uri": "spotify:artist:11chB4Th19iMA7j65oGMk1"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 218878,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/29RGtYckmyDIhFa84rD8LN"
+        },
+        "href": "https://api.spotify.com/v1/tracks/29RGtYckmyDIhFa84rD8LN",
+        "id": "29RGtYckmyDIhFa84rD8LN",
+        "name": "Scared To Be Lonely - Funkin Matt Remix",
+        "uri": "spotify:track:29RGtYckmyDIhFa84rD8LN",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "compilation",
+          "href": "https://api.spotify.com/v1/albums/5dwSRV6U5oyxplujp17RQQ",
+          "id": "5dwSRV6U5oyxplujp17RQQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731581c450d87241a23fb057e6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021581c450d87241a23fb057e6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511581c450d87241a23fb057e6",
+              "width": 64
+            }
+          ],
+          "name": "Scared To Be Lonely Remixes Vol. 1",
+          "release_date": "2017-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5dwSRV6U5oyxplujp17RQQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5dwSRV6U5oyxplujp17RQQ"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/31s2O69SopBJilGw6u6CYu"
+            },
+            "href": "https://api.spotify.com/v1/artists/31s2O69SopBJilGw6u6CYu",
+            "id": "31s2O69SopBJilGw6u6CYu",
+            "name": "Julien Earle",
+            "type": "artist",
+            "uri": "spotify:artist:31s2O69SopBJilGw6u6CYu"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 6,
+        "duration_ms": 320000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7ayQbUum7VTA22ORil79M0"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7ayQbUum7VTA22ORil79M0",
+        "id": "7ayQbUum7VTA22ORil79M0",
+        "name": "Scared To Be Lonely - Julien Earle Remix",
+        "uri": "spotify:track:7ayQbUum7VTA22ORil79M0",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2v9rQe4F8fVSh5v8bAq0jF",
+          "id": "2v9rQe4F8fVSh5v8bAq0jF",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2736a1cba0e39d52540add955c6",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e026a1cba0e39d52540add955c6",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048516a1cba0e39d52540add955c6",
+              "width": 64
+            }
+          ],
+          "name": "Scared to Be Lonely",
+          "release_date": "2017-01-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2v9rQe4F8fVSh5v8bAq0jF",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+              },
+              "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+              "id": "6M2wZ9GZgrQXHCFfjv46we",
+              "name": "Dua Lipa",
+              "type": "artist",
+              "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2v9rQe4F8fVSh5v8bAq0jF"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+            },
+            "href": "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+            "id": "6M2wZ9GZgrQXHCFfjv46we",
+            "name": "Dua Lipa",
+            "type": "artist",
+            "uri": "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 220883,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3ebXMykcMXOcLeJ9xZ17XH"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3ebXMykcMXOcLeJ9xZ17XH",
+        "id": "3ebXMykcMXOcLeJ9xZ17XH",
+        "name": "Scared to Be Lonely",
+        "uri": "spotify:track:3ebXMykcMXOcLeJ9xZ17XH",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1WSShu5SDgRFWR9ZXImKLM",
+          "id": "1WSShu5SDgRFWR9ZXImKLM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273ef0e75a3b57e0f8b74da4a11",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02ef0e75a3b57e0f8b74da4a11",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851ef0e75a3b57e0f8b74da4a11",
+              "width": 64
+            }
+          ],
+          "name": "In The Name Of Love Remixes",
+          "release_date": "2016-11-11",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1WSShu5SDgRFWR9ZXImKLM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+              },
+              "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+              "id": "64M6ah0SkkRsnPGtGiRAbb",
+              "name": "Bebe Rexha",
+              "type": "artist",
+              "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1WSShu5SDgRFWR9ZXImKLM"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+            },
+            "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+            "id": "64M6ah0SkkRsnPGtGiRAbb",
+            "name": "Bebe Rexha",
+            "type": "artist",
+            "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7uas0F5EhsZg6KDJ7yy7rW"
+            },
+            "href": "https://api.spotify.com/v1/artists/7uas0F5EhsZg6KDJ7yy7rW",
+            "id": "7uas0F5EhsZg6KDJ7yy7rW",
+            "name": "DallasK",
+            "type": "artist",
+            "uri": "spotify:artist:7uas0F5EhsZg6KDJ7yy7rW"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 200597,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/55y30bh2ZUtzOXjWLxn7XT"
+        },
+        "href": "https://api.spotify.com/v1/tracks/55y30bh2ZUtzOXjWLxn7XT",
+        "id": "55y30bh2ZUtzOXjWLxn7XT",
+        "name": "In the Name of Love - DallasK Remix",
+        "uri": "spotify:track:55y30bh2ZUtzOXjWLxn7XT",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1WSShu5SDgRFWR9ZXImKLM",
+          "id": "1WSShu5SDgRFWR9ZXImKLM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273ef0e75a3b57e0f8b74da4a11",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02ef0e75a3b57e0f8b74da4a11",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851ef0e75a3b57e0f8b74da4a11",
+              "width": 64
+            }
+          ],
+          "name": "In The Name Of Love Remixes",
+          "release_date": "2016-11-11",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1WSShu5SDgRFWR9ZXImKLM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+              },
+              "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+              "id": "64M6ah0SkkRsnPGtGiRAbb",
+              "name": "Bebe Rexha",
+              "type": "artist",
+              "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1WSShu5SDgRFWR9ZXImKLM"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+            },
+            "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+            "id": "64M6ah0SkkRsnPGtGiRAbb",
+            "name": "Bebe Rexha",
+            "type": "artist",
+            "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5WdqBAQhGFCrZvBKXiPIu7"
+            },
+            "href": "https://api.spotify.com/v1/artists/5WdqBAQhGFCrZvBKXiPIu7",
+            "id": "5WdqBAQhGFCrZvBKXiPIu7",
+            "name": "The Him",
+            "type": "artist",
+            "uri": "spotify:artist:5WdqBAQhGFCrZvBKXiPIu7"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 209280,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2sp1QtoKfxJaSlsu8NOLTn"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2sp1QtoKfxJaSlsu8NOLTn",
+        "id": "2sp1QtoKfxJaSlsu8NOLTn",
+        "name": "In The Name Of Love - The Him Remix",
+        "uri": "spotify:track:2sp1QtoKfxJaSlsu8NOLTn",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1WSShu5SDgRFWR9ZXImKLM",
+          "id": "1WSShu5SDgRFWR9ZXImKLM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273ef0e75a3b57e0f8b74da4a11",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02ef0e75a3b57e0f8b74da4a11",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851ef0e75a3b57e0f8b74da4a11",
+              "width": 64
+            }
+          ],
+          "name": "In The Name Of Love Remixes",
+          "release_date": "2016-11-11",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1WSShu5SDgRFWR9ZXImKLM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+              },
+              "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+              "id": "64M6ah0SkkRsnPGtGiRAbb",
+              "name": "Bebe Rexha",
+              "type": "artist",
+              "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1WSShu5SDgRFWR9ZXImKLM"
+          },
+          "total_tracks": 3
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+            },
+            "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+            "id": "64M6ah0SkkRsnPGtGiRAbb",
+            "name": "Bebe Rexha",
+            "type": "artist",
+            "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4xFadP7L1YVwVSjDDfjKjM"
+            },
+            "href": "https://api.spotify.com/v1/artists/4xFadP7L1YVwVSjDDfjKjM",
+            "id": "4xFadP7L1YVwVSjDDfjKjM",
+            "name": "Snavs",
+            "type": "artist",
+            "uri": "spotify:artist:4xFadP7L1YVwVSjDDfjKjM"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 180363,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/31mWJG7RF5eNvmIprY1NzI"
+        },
+        "href": "https://api.spotify.com/v1/tracks/31mWJG7RF5eNvmIprY1NzI",
+        "id": "31mWJG7RF5eNvmIprY1NzI",
+        "name": "In The Name Of Love - Snavs Remix",
+        "uri": "spotify:track:31mWJG7RF5eNvmIprY1NzI",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5wf6eVmugVxJcgHFywccWd",
+          "id": "5wf6eVmugVxJcgHFywccWd",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273c79a77e3269d575b704439b5",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02c79a77e3269d575b704439b5",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851c79a77e3269d575b704439b5",
+              "width": 64
+            }
+          ],
+          "name": "Make up Your Mind",
+          "release_date": "2016-10-21",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5wf6eVmugVxJcgHFywccWd",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4GWqzTTt2uA9Ms6HfUhWUn"
+              },
+              "href": "https://api.spotify.com/v1/artists/4GWqzTTt2uA9Ms6HfUhWUn",
+              "id": "4GWqzTTt2uA9Ms6HfUhWUn",
+              "name": "Florian Picasso",
+              "type": "artist",
+              "uri": "spotify:artist:4GWqzTTt2uA9Ms6HfUhWUn"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5wf6eVmugVxJcgHFywccWd"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4GWqzTTt2uA9Ms6HfUhWUn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4GWqzTTt2uA9Ms6HfUhWUn",
+            "id": "4GWqzTTt2uA9Ms6HfUhWUn",
+            "name": "Florian Picasso",
+            "type": "artist",
+            "uri": "spotify:artist:4GWqzTTt2uA9Ms6HfUhWUn"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 196307,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1lq8d5X2Ic0hx4t3bNDXqQ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1lq8d5X2Ic0hx4t3bNDXqQ",
+        "id": "1lq8d5X2Ic0hx4t3bNDXqQ",
+        "name": "Make up Your Mind",
+        "uri": "spotify:track:1lq8d5X2Ic0hx4t3bNDXqQ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0hqMOru1WMB5gkHS7eJequ",
+          "id": "0hqMOru1WMB5gkHS7eJequ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731c151e39ceedfa1c77788c1c",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021c151e39ceedfa1c77788c1c",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511c151e39ceedfa1c77788c1c",
+              "width": 64
+            }
+          ],
+          "name": "Together",
+          "release_date": "2016-10-20",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0hqMOru1WMB5gkHS7eJequ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0hqMOru1WMB5gkHS7eJequ"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+            },
+            "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+            "id": "2QMCcKIPHnjQaPPgoEst88",
+            "name": "Matisse & Sadko",
+            "type": "artist",
+            "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 221274,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4KX39APEOO2EgiZFkcJOfR"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4KX39APEOO2EgiZFkcJOfR",
+        "id": "4KX39APEOO2EgiZFkcJOfR",
+        "name": "Together",
+        "uri": "spotify:track:4KX39APEOO2EgiZFkcJOfR",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5cD22R50i22Gh9L1UDSBYD",
+          "id": "5cD22R50i22Gh9L1UDSBYD",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27398e097074ef6d8354f6fc5c0",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0298e097074ef6d8354f6fc5c0",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485198e097074ef6d8354f6fc5c0",
+              "width": 64
+            }
+          ],
+          "name": "Welcome",
+          "release_date": "2016-10-19",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5cD22R50i22Gh9L1UDSBYD",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+              "id": "2vUCVkeZjzDcaoX4gagHdV",
+              "name": "Julian Jordan",
+              "type": "artist",
+              "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5cD22R50i22Gh9L1UDSBYD"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+            },
+            "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+            "id": "2vUCVkeZjzDcaoX4gagHdV",
+            "name": "Julian Jordan",
+            "type": "artist",
+            "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 185105,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5ZvAZJEH4R4YEbZegv1VDK"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5ZvAZJEH4R4YEbZegv1VDK",
+        "id": "5ZvAZJEH4R4YEbZegv1VDK",
+        "name": "Welcome",
+        "uri": "spotify:track:5ZvAZJEH4R4YEbZegv1VDK",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2m9G0YAO1r7reTieBuRVmJ",
+          "id": "2m9G0YAO1r7reTieBuRVmJ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273394949e7ae8e852dc9f28776",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02394949e7ae8e852dc9f28776",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851394949e7ae8e852dc9f28776",
+              "width": 64
+            }
+          ],
+          "name": "Hold On & Believe (feat. The Federal Empire)",
+          "release_date": "2016-10-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2m9G0YAO1r7reTieBuRVmJ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2m9G0YAO1r7reTieBuRVmJ"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4PjHNisXpQqSDXOJBFRK8p"
+            },
+            "href": "https://api.spotify.com/v1/artists/4PjHNisXpQqSDXOJBFRK8p",
+            "id": "4PjHNisXpQqSDXOJBFRK8p",
+            "name": "The Federal Empire",
+            "type": "artist",
+            "uri": "spotify:artist:4PjHNisXpQqSDXOJBFRK8p"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 234389,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0raCeGWafugoSGJAA33FAa"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0raCeGWafugoSGJAA33FAa",
+        "id": "0raCeGWafugoSGJAA33FAa",
+        "name": "Hold On & Believe (feat. The Federal Empire)",
+        "uri": "spotify:track:0raCeGWafugoSGJAA33FAa",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3TEZe0MRkP0Vm530f8DPTg",
+          "id": "3TEZe0MRkP0Vm530f8DPTg",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273850f6a853ad33a91f76b9c13",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02850f6a853ad33a91f76b9c13",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851850f6a853ad33a91f76b9c13",
+              "width": 64
+            }
+          ],
+          "name": "Spotless",
+          "release_date": "2016-10-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3TEZe0MRkP0Vm530f8DPTg",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+              },
+              "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+              "id": "12SPNXi0aDpFt0rMVbmLrr",
+              "name": "Jay Hardway",
+              "type": "artist",
+              "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3TEZe0MRkP0Vm530f8DPTg"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 195019,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3lBoISh2FvtpdQt1lsU9nN"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3lBoISh2FvtpdQt1lsU9nN",
+        "id": "3lBoISh2FvtpdQt1lsU9nN",
+        "name": "Spotless",
+        "uri": "spotify:track:3lBoISh2FvtpdQt1lsU9nN",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5CqHs2WdQDh3vkwT8qRr9H",
+          "id": "5CqHs2WdQDh3vkwT8qRr9H",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27366fbc605f73a336e7390b199",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0266fbc605f73a336e7390b199",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485166fbc605f73a336e7390b199",
+              "width": 64
+            }
+          ],
+          "name": "Sun Is Never Going Down (feat. Dawn Golden)",
+          "release_date": "2016-10-16",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5CqHs2WdQDh3vkwT8qRr9H",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5CqHs2WdQDh3vkwT8qRr9H"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6MzxeKydmXufvX7HYPknFW"
+            },
+            "href": "https://api.spotify.com/v1/artists/6MzxeKydmXufvX7HYPknFW",
+            "id": "6MzxeKydmXufvX7HYPknFW",
+            "name": "Dawn Golden",
+            "type": "artist",
+            "uri": "spotify:artist:6MzxeKydmXufvX7HYPknFW"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 204418,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1NKCqXjcYZ81Budit2CQMh"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1NKCqXjcYZ81Budit2CQMh",
+        "id": "1NKCqXjcYZ81Budit2CQMh",
+        "name": "Sun Is Never Going Down (feat. Dawn Golden)",
+        "uri": "spotify:track:1NKCqXjcYZ81Budit2CQMh",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6xeK3VX1svqq1He5HR5bvb",
+          "id": "6xeK3VX1svqq1He5HR5bvb",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273aaca91bf07df0d7077bcdfc9",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02aaca91bf07df0d7077bcdfc9",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851aaca91bf07df0d7077bcdfc9",
+              "width": 64
+            }
+          ],
+          "name": "WIEE (feat. Mesto)",
+          "release_date": "2016-10-15",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6xeK3VX1svqq1He5HR5bvb",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6xeK3VX1svqq1He5HR5bvb"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+            },
+            "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+            "id": "0RViEWnZO2VhmY4oI0PhF9",
+            "name": "Mesto",
+            "type": "artist",
+            "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 203452,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6uCsQ6JlUCEKTRhC2kQjPK"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6uCsQ6JlUCEKTRhC2kQjPK",
+        "id": "6uCsQ6JlUCEKTRhC2kQjPK",
+        "name": "WIEE (feat. Mesto)",
+        "uri": "spotify:track:6uCsQ6JlUCEKTRhC2kQjPK",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1FOJ5IXGXe8dl0cXvCU6wK",
+          "id": "1FOJ5IXGXe8dl0cXvCU6wK",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273b3d48927d5a423bdbdb20166",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02b3d48927d5a423bdbdb20166",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851b3d48927d5a423bdbdb20166",
+              "width": 64
+            }
+          ],
+          "name": "In the Name of Love",
+          "release_date": "2016-07-29",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1FOJ5IXGXe8dl0cXvCU6wK",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+              },
+              "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+              "id": "64M6ah0SkkRsnPGtGiRAbb",
+              "name": "Bebe Rexha",
+              "type": "artist",
+              "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1FOJ5IXGXe8dl0cXvCU6wK"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+            },
+            "href": "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+            "id": "64M6ah0SkkRsnPGtGiRAbb",
+            "name": "Bebe Rexha",
+            "type": "artist",
+            "uri": "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 198815,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/23L5CiUhw2jV1OIMwthR3S"
+        },
+        "href": "https://api.spotify.com/v1/tracks/23L5CiUhw2jV1OIMwthR3S",
+        "id": "23L5CiUhw2jV1OIMwthR3S",
+        "name": "In the Name of Love",
+        "uri": "spotify:track:23L5CiUhw2jV1OIMwthR3S",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1DhpxDHUD5pVBUQdJCpqML",
+          "id": "1DhpxDHUD5pVBUQdJCpqML",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2730990d4783f10f2d52605abd0",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e020990d4783f10f2d52605abd0",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048510990d4783f10f2d52605abd0",
+              "width": 64
+            }
+          ],
+          "name": "Oops",
+          "release_date": "2016-06-13",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1DhpxDHUD5pVBUQdJCpqML",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1DhpxDHUD5pVBUQdJCpqML"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 232509,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/79IZKAygtVmTcVnJ2mlaIS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/79IZKAygtVmTcVnJ2mlaIS",
+        "id": "79IZKAygtVmTcVnJ2mlaIS",
+        "name": "Oops",
+        "uri": "spotify:track:79IZKAygtVmTcVnJ2mlaIS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/39GUANQpkDHusLAAJPPS7z",
+          "id": "39GUANQpkDHusLAAJPPS7z",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273bc29871e543e98c675daf9ec",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02bc29871e543e98c675daf9ec",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851bc29871e543e98c675daf9ec",
+              "width": 64
+            }
+          ],
+          "name": "Lions in the Wild",
+          "release_date": "2016-05-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:39GUANQpkDHusLAAJPPS7z",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2J80qXI4NHKpq5RT3xUF7V"
+              },
+              "href": "https://api.spotify.com/v1/artists/2J80qXI4NHKpq5RT3xUF7V",
+              "id": "2J80qXI4NHKpq5RT3xUF7V",
+              "name": "Third Party",
+              "type": "artist",
+              "uri": "spotify:artist:2J80qXI4NHKpq5RT3xUF7V"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/39GUANQpkDHusLAAJPPS7z"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2J80qXI4NHKpq5RT3xUF7V"
+            },
+            "href": "https://api.spotify.com/v1/artists/2J80qXI4NHKpq5RT3xUF7V",
+            "id": "2J80qXI4NHKpq5RT3xUF7V",
+            "name": "Third Party",
+            "type": "artist",
+            "uri": "spotify:artist:2J80qXI4NHKpq5RT3xUF7V"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 211889,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6F1kPSgdnlSzZRfskE9vaV"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6F1kPSgdnlSzZRfskE9vaV",
+        "id": "6F1kPSgdnlSzZRfskE9vaV",
+        "name": "Lions in the Wild",
+        "uri": "spotify:track:6F1kPSgdnlSzZRfskE9vaV",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2HtWz2HnIBnS4ErQywXnpx",
+          "id": "2HtWz2HnIBnS4ErQywXnpx",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d195bdd6b64276991794d986",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d195bdd6b64276991794d986",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d195bdd6b64276991794d986",
+              "width": 64
+            }
+          ],
+          "name": "Now That I've Found You (feat. John & Michel)",
+          "release_date": "2016-03-11",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2HtWz2HnIBnS4ErQywXnpx",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2HtWz2HnIBnS4ErQywXnpx"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7HKKVg8EvYKCjwzOLhnujL"
+            },
+            "href": "https://api.spotify.com/v1/artists/7HKKVg8EvYKCjwzOLhnujL",
+            "id": "7HKKVg8EvYKCjwzOLhnujL",
+            "name": "John & Michel",
+            "type": "artist",
+            "uri": "spotify:artist:7HKKVg8EvYKCjwzOLhnujL"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 192631,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7wZorJD5loL9ceLJ67sg6S"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7wZorJD5loL9ceLJ67sg6S",
+        "id": "7wZorJD5loL9ceLJ67sg6S",
+        "name": "Now That I've Found You (feat. John & Michel)",
+        "uri": "spotify:track:7wZorJD5loL9ceLJ67sg6S",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0r2CYC1JLU7EyYEJeKBdJM",
+          "id": "0r2CYC1JLU7EyYEJeKBdJM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a5794a512b65c5d469f01f47",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a5794a512b65c5d469f01f47",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a5794a512b65c5d469f01f47",
+              "width": 64
+            }
+          ],
+          "name": "Bouncybob (feat. Justin Mylo & Mesto)",
+          "release_date": "2015-12-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0r2CYC1JLU7EyYEJeKBdJM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0r2CYC1JLU7EyYEJeKBdJM"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7MFJyevu6jq0shwDuVLymu"
+            },
+            "href": "https://api.spotify.com/v1/artists/7MFJyevu6jq0shwDuVLymu",
+            "id": "7MFJyevu6jq0shwDuVLymu",
+            "name": "Justin Mylo",
+            "type": "artist",
+            "uri": "spotify:artist:7MFJyevu6jq0shwDuVLymu"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+            },
+            "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+            "id": "0RViEWnZO2VhmY4oI0PhF9",
+            "name": "Mesto",
+            "type": "artist",
+            "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 251259,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0MyfJah9XRKoF68chrxVmZ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0MyfJah9XRKoF68chrxVmZ",
+        "id": "0MyfJah9XRKoF68chrxVmZ",
+        "name": "Bouncybob (feat. Justin Mylo & Mesto)",
+        "uri": "spotify:track:0MyfJah9XRKoF68chrxVmZ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/2m4U0aYL6QDgbkL5GFbCmn",
+          "id": "2m4U0aYL6QDgbkL5GFbCmn",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2731d5d7e5284b02467a27f686a",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e021d5d7e5284b02467a27f686a",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048511d5d7e5284b02467a27f686a",
+              "width": 64
+            }
+          ],
+          "name": "Poison",
+          "release_date": "2015-11-02",
+          "release_date_precision": "day",
+          "uri": "spotify:album:2m4U0aYL6QDgbkL5GFbCmn",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/2m4U0aYL6QDgbkL5GFbCmn"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 248447,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4ZkVOb0mNnm3MFY2LeyqHY"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4ZkVOb0mNnm3MFY2LeyqHY",
+        "id": "4ZkVOb0mNnm3MFY2LeyqHY",
+        "name": "Poison",
+        "uri": "spotify:track:4ZkVOb0mNnm3MFY2LeyqHY",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/12yYl13Ce7u8LuhtEl75aQ",
+          "id": "12yYl13Ce7u8LuhtEl75aQ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273364aec7419abbc2f5aeaaeda",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02364aec7419abbc2f5aeaaeda",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851364aec7419abbc2f5aeaaeda",
+              "width": 64
+            }
+          ],
+          "name": "Can't Feel My Face (Martin Garrix Remix)",
+          "release_date": "2015-11-06",
+          "release_date_precision": "day",
+          "uri": "spotify:album:12yYl13Ce7u8LuhtEl75aQ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Xyo4u8uXC1ZmMpatF05PJ"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Xyo4u8uXC1ZmMpatF05PJ",
+              "id": "1Xyo4u8uXC1ZmMpatF05PJ",
+              "name": "The Weeknd",
+              "type": "artist",
+              "uri": "spotify:artist:1Xyo4u8uXC1ZmMpatF05PJ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/12yYl13Ce7u8LuhtEl75aQ"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Xyo4u8uXC1ZmMpatF05PJ"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Xyo4u8uXC1ZmMpatF05PJ",
+            "id": "1Xyo4u8uXC1ZmMpatF05PJ",
+            "name": "The Weeknd",
+            "type": "artist",
+            "uri": "spotify:artist:1Xyo4u8uXC1ZmMpatF05PJ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 252933,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/22SXyL6pUjwIvGWvgGjLov"
+        },
+        "href": "https://api.spotify.com/v1/tracks/22SXyL6pUjwIvGWvgGjLov",
+        "id": "22SXyL6pUjwIvGWvgGjLov",
+        "name": "Can't Feel My Face - Martin Garrix Remix",
+        "uri": "spotify:track:22SXyL6pUjwIvGWvgGjLov",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0A8WPEctABHnBj6pE2aoA6",
+          "id": "0A8WPEctABHnBj6pE2aoA6",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273163754972bce914ee94e08b8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02163754972bce914ee94e08b8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851163754972bce914ee94e08b8",
+              "width": 64
+            }
+          ],
+          "name": "Break Through The Silence EP",
+          "release_date": "2015-08-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0A8WPEctABHnBj6pE2aoA6",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0A8WPEctABHnBj6pE2aoA6"
+          },
+          "total_tracks": 2
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+            },
+            "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+            "id": "2QMCcKIPHnjQaPPgoEst88",
+            "name": "Matisse & Sadko",
+            "type": "artist",
+            "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 283139,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2hSltlbnyQtKvfaZ1EjljN"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2hSltlbnyQtKvfaZ1EjljN",
+        "id": "2hSltlbnyQtKvfaZ1EjljN",
+        "name": "Break Through The Silence - Original Mix",
+        "uri": "spotify:track:2hSltlbnyQtKvfaZ1EjljN",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0A8WPEctABHnBj6pE2aoA6",
+          "id": "0A8WPEctABHnBj6pE2aoA6",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273163754972bce914ee94e08b8",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02163754972bce914ee94e08b8",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851163754972bce914ee94e08b8",
+              "width": 64
+            }
+          ],
+          "name": "Break Through The Silence EP",
+          "release_date": "2015-08-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0A8WPEctABHnBj6pE2aoA6",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0A8WPEctABHnBj6pE2aoA6"
+          },
+          "total_tracks": 2
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+            },
+            "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+            "id": "2QMCcKIPHnjQaPPgoEst88",
+            "name": "Matisse & Sadko",
+            "type": "artist",
+            "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 296250,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5RTcqTN4gSFNHrk6gV74mZ"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5RTcqTN4gSFNHrk6gV74mZ",
+        "id": "5RTcqTN4gSFNHrk6gV74mZ",
+        "name": "Dragon - Original Mix",
+        "uri": "spotify:track:5RTcqTN4gSFNHrk6gV74mZ",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7e4eCJT5ON1FpJD5Si341e",
+          "id": "7e4eCJT5ON1FpJD5Si341e",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273de034bbdbe12c86285356121",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02de034bbdbe12c86285356121",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851de034bbdbe12c86285356121",
+              "width": 64
+            }
+          ],
+          "name": "Don't Look Down (feat. Usher)",
+          "release_date": "2015-03-17",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7e4eCJT5ON1FpJD5Si341e",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7e4eCJT5ON1FpJD5Si341e"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/23zg3TcAtWQy7J6upgbUnj"
+            },
+            "href": "https://api.spotify.com/v1/artists/23zg3TcAtWQy7J6upgbUnj",
+            "id": "23zg3TcAtWQy7J6upgbUnj",
+            "name": "USHER",
+            "type": "artist",
+            "uri": "spotify:artist:23zg3TcAtWQy7J6upgbUnj"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 223139,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5M9jOReAKGZ2AttVefFjTY"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5M9jOReAKGZ2AttVefFjTY",
+        "id": "5M9jOReAKGZ2AttVefFjTY",
+        "name": "Don't Look Down (feat. Usher)",
+        "uri": "spotify:track:5M9jOReAKGZ2AttVefFjTY",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    }
+  ],
+  "limit": 100,
+  "next": "https://api.spotify.com/v1/playlists/testId/items?offset=200&limit=100",
+  "offset": 100,
+  "previous": "https://api.spotify.com/v1/playlists/testId/items?offset=0&limit=100",
+  "total": 231
+}

--- a/tests/mock_fixtures/mocked_get_large_playlist_items_response_page_3.json
+++ b/tests/mock_fixtures/mocked_get_large_playlist_items_response_page_3.json
@@ -1,0 +1,3484 @@
+{
+  "href": "https://api.spotify.com/v1/playlists/testId/items?offset=200&limit=100",
+  "items": [
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/26oYqQO1MNxFLMfPttGRSS",
+          "id": "26oYqQO1MNxFLMfPttGRSS",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273abca63817c6931c674348a4d",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02abca63817c6931c674348a4d",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851abca63817c6931c674348a4d",
+              "width": 64
+            }
+          ],
+          "name": "Forbidden Voices",
+          "release_date": "2015-02-23",
+          "release_date_precision": "day",
+          "uri": "spotify:album:26oYqQO1MNxFLMfPttGRSS",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/26oYqQO1MNxFLMfPttGRSS"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 230634,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2BF1X5nkYYSb0AUTRaGkDm"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2BF1X5nkYYSb0AUTRaGkDm",
+        "id": "2BF1X5nkYYSb0AUTRaGkDm",
+        "name": "Forbidden Voices",
+        "uri": "spotify:track:2BF1X5nkYYSb0AUTRaGkDm",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5kLRzKHClRO3TX5LeSzljZ",
+          "id": "5kLRzKHClRO3TX5LeSzljZ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27317d5a6bee8c363972c743b7f",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0217d5a6bee8c363972c743b7f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485117d5a6bee8c363972c743b7f",
+              "width": 64
+            }
+          ],
+          "name": "Virus (How About Now)",
+          "release_date": "2014-10-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5kLRzKHClRO3TX5LeSzljZ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1vo8zHmO1KzkuU9Xxh6J7W"
+              },
+              "href": "https://api.spotify.com/v1/artists/1vo8zHmO1KzkuU9Xxh6J7W",
+              "id": "1vo8zHmO1KzkuU9Xxh6J7W",
+              "name": "MOTi",
+              "type": "artist",
+              "uri": "spotify:artist:1vo8zHmO1KzkuU9Xxh6J7W"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5kLRzKHClRO3TX5LeSzljZ"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1vo8zHmO1KzkuU9Xxh6J7W"
+            },
+            "href": "https://api.spotify.com/v1/artists/1vo8zHmO1KzkuU9Xxh6J7W",
+            "id": "1vo8zHmO1KzkuU9Xxh6J7W",
+            "name": "MOTi",
+            "type": "artist",
+            "uri": "spotify:artist:1vo8zHmO1KzkuU9Xxh6J7W"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 198077,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5ZnzVZrSja6miEOxZIV8Q6"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5ZnzVZrSja6miEOxZIV8Q6",
+        "id": "5ZnzVZrSja6miEOxZIV8Q6",
+        "name": "Virus (How About Now)",
+        "uri": "spotify:track:5ZnzVZrSja6miEOxZIV8Q6",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "album",
+          "href": "https://api.spotify.com/v1/albums/4RSvuzDzXPyWK0qKWn8nQl",
+          "id": "4RSvuzDzXPyWK0qKWn8nQl",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733f46bdec7bc4a8602cb828ba",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023f46bdec7bc4a8602cb828ba",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513f46bdec7bc4a8602cb828ba",
+              "width": 64
+            }
+          ],
+          "name": "Money Sucks, Friends Rule (10 Year Remix Album)",
+          "release_date": "2024-10-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4RSvuzDzXPyWK0qKWn8nQl",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5R3Hr2cnCCjt220Jmt2xLf"
+              },
+              "href": "https://api.spotify.com/v1/artists/5R3Hr2cnCCjt220Jmt2xLf",
+              "id": "5R3Hr2cnCCjt220Jmt2xLf",
+              "name": "Dillon Francis",
+              "type": "artist",
+              "uri": "spotify:artist:5R3Hr2cnCCjt220Jmt2xLf"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4RSvuzDzXPyWK0qKWn8nQl"
+          },
+          "total_tracks": 8
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5R3Hr2cnCCjt220Jmt2xLf"
+            },
+            "href": "https://api.spotify.com/v1/artists/5R3Hr2cnCCjt220Jmt2xLf",
+            "id": "5R3Hr2cnCCjt220Jmt2xLf",
+            "name": "Dillon Francis",
+            "type": "artist",
+            "uri": "spotify:artist:5R3Hr2cnCCjt220Jmt2xLf"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 196118,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4DTz0SsUbgqO4Rzc4IBGvt"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4DTz0SsUbgqO4Rzc4IBGvt",
+        "id": "4DTz0SsUbgqO4Rzc4IBGvt",
+        "name": "Set Me Free - Dillon Francis VIP",
+        "uri": "spotify:track:4DTz0SsUbgqO4Rzc4IBGvt",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "album",
+          "href": "https://api.spotify.com/v1/albums/4RSvuzDzXPyWK0qKWn8nQl",
+          "id": "4RSvuzDzXPyWK0qKWn8nQl",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733f46bdec7bc4a8602cb828ba",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023f46bdec7bc4a8602cb828ba",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513f46bdec7bc4a8602cb828ba",
+              "width": 64
+            }
+          ],
+          "name": "Money Sucks, Friends Rule (10 Year Remix Album)",
+          "release_date": "2024-10-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4RSvuzDzXPyWK0qKWn8nQl",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5R3Hr2cnCCjt220Jmt2xLf"
+              },
+              "href": "https://api.spotify.com/v1/artists/5R3Hr2cnCCjt220Jmt2xLf",
+              "id": "5R3Hr2cnCCjt220Jmt2xLf",
+              "name": "Dillon Francis",
+              "type": "artist",
+              "uri": "spotify:artist:5R3Hr2cnCCjt220Jmt2xLf"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4RSvuzDzXPyWK0qKWn8nQl"
+          },
+          "total_tracks": 8
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5R3Hr2cnCCjt220Jmt2xLf"
+            },
+            "href": "https://api.spotify.com/v1/artists/5R3Hr2cnCCjt220Jmt2xLf",
+            "id": "5R3Hr2cnCCjt220Jmt2xLf",
+            "name": "Dillon Francis",
+            "type": "artist",
+            "uri": "spotify:artist:5R3Hr2cnCCjt220Jmt2xLf"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+            },
+            "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+            "id": "2vUCVkeZjzDcaoX4gagHdV",
+            "name": "Julian Jordan",
+            "type": "artist",
+            "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 5,
+        "duration_ms": 169870,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1MD4DLMnVk1E6CHQk1a5r2"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1MD4DLMnVk1E6CHQk1a5r2",
+        "id": "1MD4DLMnVk1E6CHQk1a5r2",
+        "name": "Set Me Free - Julian Jordan Remix",
+        "uri": "spotify:track:1MD4DLMnVk1E6CHQk1a5r2",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/5sjOxT8Pln6BdtGaRHjPGN",
+          "id": "5sjOxT8Pln6BdtGaRHjPGN",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273b0f12a0c6ebea6ccd2c3a5e5",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02b0f12a0c6ebea6ccd2c3a5e5",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851b0f12a0c6ebea6ccd2c3a5e5",
+              "width": 64
+            }
+          ],
+          "name": "Set Me Free",
+          "release_date": "2014-10-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:5sjOxT8Pln6BdtGaRHjPGN",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5R3Hr2cnCCjt220Jmt2xLf"
+              },
+              "href": "https://api.spotify.com/v1/artists/5R3Hr2cnCCjt220Jmt2xLf",
+              "id": "5R3Hr2cnCCjt220Jmt2xLf",
+              "name": "Dillon Francis",
+              "type": "artist",
+              "uri": "spotify:artist:5R3Hr2cnCCjt220Jmt2xLf"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/5sjOxT8Pln6BdtGaRHjPGN"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5R3Hr2cnCCjt220Jmt2xLf"
+            },
+            "href": "https://api.spotify.com/v1/artists/5R3Hr2cnCCjt220Jmt2xLf",
+            "id": "5R3Hr2cnCCjt220Jmt2xLf",
+            "name": "Dillon Francis",
+            "type": "artist",
+            "uri": "spotify:artist:5R3Hr2cnCCjt220Jmt2xLf"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 247360,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0r5EDdtVbAhXW988ZsLQnd"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0r5EDdtVbAhXW988ZsLQnd",
+        "id": "0r5EDdtVbAhXW988ZsLQnd",
+        "name": "Set Me Free",
+        "uri": "spotify:track:0r5EDdtVbAhXW988ZsLQnd",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6WAiRWtxdokJgZiFqh1V6R",
+          "id": "6WAiRWtxdokJgZiFqh1V6R",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273cd8a699d934d94930c4b2d35",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02cd8a699d934d94930c4b2d35",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851cd8a699d934d94930c4b2d35",
+              "width": 64
+            }
+          ],
+          "name": "Gold Skies",
+          "release_date": "2014-06-06",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6WAiRWtxdokJgZiFqh1V6R",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+              },
+              "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+              "id": "22bukBZvUppuwQwmDz75Gz",
+              "name": "Sander van Doorn",
+              "type": "artist",
+              "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+              },
+              "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+              "id": "5X4LWwbUFNzPkEas04uU82",
+              "name": "DVBBS",
+              "type": "artist",
+              "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6WAiRWtxdokJgZiFqh1V6R"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+            },
+            "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+            "id": "22bukBZvUppuwQwmDz75Gz",
+            "name": "Sander van Doorn",
+            "type": "artist",
+            "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+            },
+            "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+            "id": "5X4LWwbUFNzPkEas04uU82",
+            "name": "DVBBS",
+            "type": "artist",
+            "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1KV1BqrUpebQPqVU2r89xc"
+            },
+            "href": "https://api.spotify.com/v1/artists/1KV1BqrUpebQPqVU2r89xc",
+            "id": "1KV1BqrUpebQPqVU2r89xc",
+            "name": "Aleesia",
+            "type": "artist",
+            "uri": "spotify:artist:1KV1BqrUpebQPqVU2r89xc"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 235327,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1opkP7MsGYWprn3Z7j53At"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1opkP7MsGYWprn3Z7j53At",
+        "id": "1opkP7MsGYWprn3Z7j53At",
+        "name": "Gold Skies",
+        "uri": "spotify:track:1opkP7MsGYWprn3Z7j53At",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/4RzfNzvOUfjQqW63TI9wgS",
+          "id": "4RzfNzvOUfjQqW63TI9wgS",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a8e83e9fe938779f21f50372",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a8e83e9fe938779f21f50372",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a8e83e9fe938779f21f50372",
+              "width": 64
+            }
+          ],
+          "name": "Gold Skies (The Remixes Part 1)",
+          "release_date": "2014-09-22",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4RzfNzvOUfjQqW63TI9wgS",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+              },
+              "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+              "id": "22bukBZvUppuwQwmDz75Gz",
+              "name": "Sander van Doorn",
+              "type": "artist",
+              "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+              },
+              "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+              "id": "5X4LWwbUFNzPkEas04uU82",
+              "name": "DVBBS",
+              "type": "artist",
+              "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4RzfNzvOUfjQqW63TI9wgS"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+            },
+            "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+            "id": "22bukBZvUppuwQwmDz75Gz",
+            "name": "Sander van Doorn",
+            "type": "artist",
+            "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+            },
+            "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+            "id": "5X4LWwbUFNzPkEas04uU82",
+            "name": "DVBBS",
+            "type": "artist",
+            "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1KV1BqrUpebQPqVU2r89xc"
+            },
+            "href": "https://api.spotify.com/v1/artists/1KV1BqrUpebQPqVU2r89xc",
+            "id": "1KV1BqrUpebQPqVU2r89xc",
+            "name": "Aleesia",
+            "type": "artist",
+            "uri": "spotify:artist:1KV1BqrUpebQPqVU2r89xc"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2o5jDhtHVPhrJdv3cEQ99Z"
+            },
+            "href": "https://api.spotify.com/v1/artists/2o5jDhtHVPhrJdv3cEQ99Z",
+            "id": "2o5jDhtHVPhrJdv3cEQ99Z",
+            "name": "Tiësto",
+            "type": "artist",
+            "uri": "spotify:artist:2o5jDhtHVPhrJdv3cEQ99Z"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 306102,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7bKWpXmubyw8iJDUsMaRkr"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7bKWpXmubyw8iJDUsMaRkr",
+        "id": "7bKWpXmubyw8iJDUsMaRkr",
+        "name": "Gold Skies - Tiësto Remix",
+        "uri": "spotify:track:7bKWpXmubyw8iJDUsMaRkr",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/4RzfNzvOUfjQqW63TI9wgS",
+          "id": "4RzfNzvOUfjQqW63TI9wgS",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a8e83e9fe938779f21f50372",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a8e83e9fe938779f21f50372",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a8e83e9fe938779f21f50372",
+              "width": 64
+            }
+          ],
+          "name": "Gold Skies (The Remixes Part 1)",
+          "release_date": "2014-09-22",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4RzfNzvOUfjQqW63TI9wgS",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+              },
+              "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+              "id": "22bukBZvUppuwQwmDz75Gz",
+              "name": "Sander van Doorn",
+              "type": "artist",
+              "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+              },
+              "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+              "id": "5X4LWwbUFNzPkEas04uU82",
+              "name": "DVBBS",
+              "type": "artist",
+              "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4RzfNzvOUfjQqW63TI9wgS"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+            },
+            "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+            "id": "22bukBZvUppuwQwmDz75Gz",
+            "name": "Sander van Doorn",
+            "type": "artist",
+            "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+            },
+            "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+            "id": "5X4LWwbUFNzPkEas04uU82",
+            "name": "DVBBS",
+            "type": "artist",
+            "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1KV1BqrUpebQPqVU2r89xc"
+            },
+            "href": "https://api.spotify.com/v1/artists/1KV1BqrUpebQPqVU2r89xc",
+            "id": "1KV1BqrUpebQPqVU2r89xc",
+            "name": "Aleesia",
+            "type": "artist",
+            "uri": "spotify:artist:1KV1BqrUpebQPqVU2r89xc"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+            },
+            "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+            "id": "3XINWZaloea97SIRiyTJxX",
+            "name": "DubVision",
+            "type": "artist",
+            "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 311250,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0N84STI4Klm86q7TfgVuhS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0N84STI4Klm86q7TfgVuhS",
+        "id": "0N84STI4Klm86q7TfgVuhS",
+        "name": "Gold Skies - DubVision Remix",
+        "uri": "spotify:track:0N84STI4Klm86q7TfgVuhS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/4RzfNzvOUfjQqW63TI9wgS",
+          "id": "4RzfNzvOUfjQqW63TI9wgS",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a8e83e9fe938779f21f50372",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a8e83e9fe938779f21f50372",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a8e83e9fe938779f21f50372",
+              "width": 64
+            }
+          ],
+          "name": "Gold Skies (The Remixes Part 1)",
+          "release_date": "2014-09-22",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4RzfNzvOUfjQqW63TI9wgS",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+              },
+              "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+              "id": "22bukBZvUppuwQwmDz75Gz",
+              "name": "Sander van Doorn",
+              "type": "artist",
+              "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+              },
+              "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+              "id": "5X4LWwbUFNzPkEas04uU82",
+              "name": "DVBBS",
+              "type": "artist",
+              "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4RzfNzvOUfjQqW63TI9wgS"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+            },
+            "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+            "id": "22bukBZvUppuwQwmDz75Gz",
+            "name": "Sander van Doorn",
+            "type": "artist",
+            "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+            },
+            "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+            "id": "5X4LWwbUFNzPkEas04uU82",
+            "name": "DVBBS",
+            "type": "artist",
+            "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1KV1BqrUpebQPqVU2r89xc"
+            },
+            "href": "https://api.spotify.com/v1/artists/1KV1BqrUpebQPqVU2r89xc",
+            "id": "1KV1BqrUpebQPqVU2r89xc",
+            "name": "Aleesia",
+            "type": "artist",
+            "uri": "spotify:artist:1KV1BqrUpebQPqVU2r89xc"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Sst6GQgTy9e0QxrQX2Uyb"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Sst6GQgTy9e0QxrQX2Uyb",
+            "id": "1Sst6GQgTy9e0QxrQX2Uyb",
+            "name": "Overused",
+            "type": "artist",
+            "uri": "spotify:artist:1Sst6GQgTy9e0QxrQX2Uyb"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 256753,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/42IenLbjXjiK7RXff3wAcf"
+        },
+        "href": "https://api.spotify.com/v1/tracks/42IenLbjXjiK7RXff3wAcf",
+        "id": "42IenLbjXjiK7RXff3wAcf",
+        "name": "Gold Skies - Overused Remix",
+        "uri": "spotify:track:42IenLbjXjiK7RXff3wAcf",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/4RzfNzvOUfjQqW63TI9wgS",
+          "id": "4RzfNzvOUfjQqW63TI9wgS",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a8e83e9fe938779f21f50372",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a8e83e9fe938779f21f50372",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a8e83e9fe938779f21f50372",
+              "width": 64
+            }
+          ],
+          "name": "Gold Skies (The Remixes Part 1)",
+          "release_date": "2014-09-22",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4RzfNzvOUfjQqW63TI9wgS",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+              },
+              "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+              "id": "22bukBZvUppuwQwmDz75Gz",
+              "name": "Sander van Doorn",
+              "type": "artist",
+              "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+              },
+              "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+              "id": "5X4LWwbUFNzPkEas04uU82",
+              "name": "DVBBS",
+              "type": "artist",
+              "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4RzfNzvOUfjQqW63TI9wgS"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/22bukBZvUppuwQwmDz75Gz"
+            },
+            "href": "https://api.spotify.com/v1/artists/22bukBZvUppuwQwmDz75Gz",
+            "id": "22bukBZvUppuwQwmDz75Gz",
+            "name": "Sander van Doorn",
+            "type": "artist",
+            "uri": "spotify:artist:22bukBZvUppuwQwmDz75Gz"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5X4LWwbUFNzPkEas04uU82"
+            },
+            "href": "https://api.spotify.com/v1/artists/5X4LWwbUFNzPkEas04uU82",
+            "id": "5X4LWwbUFNzPkEas04uU82",
+            "name": "DVBBS",
+            "type": "artist",
+            "uri": "spotify:artist:5X4LWwbUFNzPkEas04uU82"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1KV1BqrUpebQPqVU2r89xc"
+            },
+            "href": "https://api.spotify.com/v1/artists/1KV1BqrUpebQPqVU2r89xc",
+            "id": "1KV1BqrUpebQPqVU2r89xc",
+            "name": "Aleesia",
+            "type": "artist",
+            "uri": "spotify:artist:1KV1BqrUpebQPqVU2r89xc"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3cnAJv9gydgm52KFIsdvO8"
+            },
+            "href": "https://api.spotify.com/v1/artists/3cnAJv9gydgm52KFIsdvO8",
+            "id": "3cnAJv9gydgm52KFIsdvO8",
+            "name": "Ferreck Dawn",
+            "type": "artist",
+            "uri": "spotify:artist:3cnAJv9gydgm52KFIsdvO8"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3T0HSMgUpuH1hXbT1JPwQF"
+            },
+            "href": "https://api.spotify.com/v1/artists/3T0HSMgUpuH1hXbT1JPwQF",
+            "id": "3T0HSMgUpuH1hXbT1JPwQF",
+            "name": "Redondo",
+            "type": "artist",
+            "uri": "spotify:artist:3T0HSMgUpuH1hXbT1JPwQF"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 379245,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1LK6TpWB83EndqSPSJf1Wh"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1LK6TpWB83EndqSPSJf1Wh",
+        "id": "1LK6TpWB83EndqSPSJf1Wh",
+        "name": "Gold Skies - Ferreck Dawn & Redondo Remix",
+        "uri": "spotify:track:1LK6TpWB83EndqSPSJf1Wh",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/38JiXXsbwnPED5NkNMBrax",
+          "id": "38JiXXsbwnPED5NkNMBrax",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27342c4be28f00cf37fa676221b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0242c4be28f00cf37fa676221b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485142c4be28f00cf37fa676221b",
+              "width": 64
+            }
+          ],
+          "name": "Turn Up The Speakers",
+          "release_date": "2014-08-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:38JiXXsbwnPED5NkNMBrax",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4D75GcNG95ebPtNvoNVXhz"
+              },
+              "href": "https://api.spotify.com/v1/artists/4D75GcNG95ebPtNvoNVXhz",
+              "id": "4D75GcNG95ebPtNvoNVXhz",
+              "name": "AFROJACK",
+              "type": "artist",
+              "uri": "spotify:artist:4D75GcNG95ebPtNvoNVXhz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/38JiXXsbwnPED5NkNMBrax"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4D75GcNG95ebPtNvoNVXhz"
+            },
+            "href": "https://api.spotify.com/v1/artists/4D75GcNG95ebPtNvoNVXhz",
+            "id": "4D75GcNG95ebPtNvoNVXhz",
+            "name": "AFROJACK",
+            "type": "artist",
+            "uri": "spotify:artist:4D75GcNG95ebPtNvoNVXhz"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 183750,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2F9zf32Q3DFz977NmSt58Y"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2F9zf32Q3DFz977NmSt58Y",
+        "id": "2F9zf32Q3DFz977NmSt58Y",
+        "name": "Turn Up The Speakers",
+        "uri": "spotify:track:2F9zf32Q3DFz977NmSt58Y",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/65Qz6GlGuY2iXqm9d8j0XM",
+          "id": "65Qz6GlGuY2iXqm9d8j0XM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273c0f9319b7277e99b52d5b72b",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02c0f9319b7277e99b52d5b72b",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851c0f9319b7277e99b52d5b72b",
+              "width": 64
+            }
+          ],
+          "name": "Tremor (Sensation 2014 Anthem)",
+          "release_date": "2014-05-05",
+          "release_date_precision": "day",
+          "uri": "spotify:album:65Qz6GlGuY2iXqm9d8j0XM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/73jBynjsVtofjRpdpRAJGk"
+              },
+              "href": "https://api.spotify.com/v1/artists/73jBynjsVtofjRpdpRAJGk",
+              "id": "73jBynjsVtofjRpdpRAJGk",
+              "name": "Dimitri Vegas & Like Mike",
+              "type": "artist",
+              "uri": "spotify:artist:73jBynjsVtofjRpdpRAJGk"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/65Qz6GlGuY2iXqm9d8j0XM"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/73jBynjsVtofjRpdpRAJGk"
+            },
+            "href": "https://api.spotify.com/v1/artists/73jBynjsVtofjRpdpRAJGk",
+            "id": "73jBynjsVtofjRpdpRAJGk",
+            "name": "Dimitri Vegas & Like Mike",
+            "type": "artist",
+            "uri": "spotify:artist:73jBynjsVtofjRpdpRAJGk"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 193139,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6GNIcpcbeWxSH1TJgmGDl7"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6GNIcpcbeWxSH1TJgmGDl7",
+        "id": "6GNIcpcbeWxSH1TJgmGDl7",
+        "name": "Tremor (Sensation 2014 Anthem) - Radio Edit",
+        "uri": "spotify:track:6GNIcpcbeWxSH1TJgmGDl7",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/24NKj9pKgI7RhIwUNTBJTM",
+          "id": "24NKj9pKgI7RhIwUNTBJTM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273ca9f6afde4e52f9d0c726e70",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02ca9f6afde4e52f9d0c726e70",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851ca9f6afde4e52f9d0c726e70",
+              "width": 64
+            }
+          ],
+          "name": "Wizard Minimix (Spotify Exclusive)",
+          "release_date": "2013-12-02",
+          "release_date_precision": "day",
+          "uri": "spotify:album:24NKj9pKgI7RhIwUNTBJTM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/24NKj9pKgI7RhIwUNTBJTM"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 202411,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4mBBIeQRAwymY79njJHsiE"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4mBBIeQRAwymY79njJHsiE",
+        "id": "4mBBIeQRAwymY79njJHsiE",
+        "name": "Wizard",
+        "uri": "spotify:track:4mBBIeQRAwymY79njJHsiE",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3UeAYPILU0r0fRhTp3FL9V",
+          "id": "3UeAYPILU0r0fRhTp3FL9V",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27387b105a445ae69f7c4a8d480",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0287b105a445ae69f7c4a8d480",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485187b105a445ae69f7c4a8d480",
+              "width": 64
+            }
+          ],
+          "name": "Wizard (The Remixes)",
+          "release_date": "2014-03-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3UeAYPILU0r0fRhTp3FL9V",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+              },
+              "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+              "id": "12SPNXi0aDpFt0rMVbmLrr",
+              "name": "Jay Hardway",
+              "type": "artist",
+              "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3UeAYPILU0r0fRhTp3FL9V"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1KpCi9BOfviCVhmpI4G2sY"
+            },
+            "href": "https://api.spotify.com/v1/artists/1KpCi9BOfviCVhmpI4G2sY",
+            "id": "1KpCi9BOfviCVhmpI4G2sY",
+            "name": "Tchami",
+            "type": "artist",
+            "uri": "spotify:artist:1KpCi9BOfviCVhmpI4G2sY"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 336774,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/7K8TZ6No9MMZ4hrNfsYgvs"
+        },
+        "href": "https://api.spotify.com/v1/tracks/7K8TZ6No9MMZ4hrNfsYgvs",
+        "id": "7K8TZ6No9MMZ4hrNfsYgvs",
+        "name": "Wizard - Tchami Remix",
+        "uri": "spotify:track:7K8TZ6No9MMZ4hrNfsYgvs",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3UeAYPILU0r0fRhTp3FL9V",
+          "id": "3UeAYPILU0r0fRhTp3FL9V",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27387b105a445ae69f7c4a8d480",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0287b105a445ae69f7c4a8d480",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485187b105a445ae69f7c4a8d480",
+              "width": 64
+            }
+          ],
+          "name": "Wizard (The Remixes)",
+          "release_date": "2014-03-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3UeAYPILU0r0fRhTp3FL9V",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+              },
+              "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+              "id": "12SPNXi0aDpFt0rMVbmLrr",
+              "name": "Jay Hardway",
+              "type": "artist",
+              "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3UeAYPILU0r0fRhTp3FL9V"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0eW2N88UpBG0giW7LJOaY2"
+            },
+            "href": "https://api.spotify.com/v1/artists/0eW2N88UpBG0giW7LJOaY2",
+            "id": "0eW2N88UpBG0giW7LJOaY2",
+            "name": "Mike Hawkins",
+            "type": "artist",
+            "uri": "spotify:artist:0eW2N88UpBG0giW7LJOaY2"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 215806,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5WUwQVOA6nXkJVNikicYR0"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5WUwQVOA6nXkJVNikicYR0",
+        "id": "5WUwQVOA6nXkJVNikicYR0",
+        "name": "Wizard - Mike Hawkins Remix",
+        "uri": "spotify:track:5WUwQVOA6nXkJVNikicYR0",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3UeAYPILU0r0fRhTp3FL9V",
+          "id": "3UeAYPILU0r0fRhTp3FL9V",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27387b105a445ae69f7c4a8d480",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0287b105a445ae69f7c4a8d480",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485187b105a445ae69f7c4a8d480",
+              "width": 64
+            }
+          ],
+          "name": "Wizard (The Remixes)",
+          "release_date": "2014-03-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3UeAYPILU0r0fRhTp3FL9V",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+              },
+              "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+              "id": "12SPNXi0aDpFt0rMVbmLrr",
+              "name": "Jay Hardway",
+              "type": "artist",
+              "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3UeAYPILU0r0fRhTp3FL9V"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/47z7ZrgFoBvVpCnElCE3Zh"
+            },
+            "href": "https://api.spotify.com/v1/artists/47z7ZrgFoBvVpCnElCE3Zh",
+            "id": "47z7ZrgFoBvVpCnElCE3Zh",
+            "name": "Yellow Claw",
+            "type": "artist",
+            "uri": "spotify:artist:47z7ZrgFoBvVpCnElCE3Zh"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 218491,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5KpJ0jaMr0UusAxQ0R1RFS"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5KpJ0jaMr0UusAxQ0R1RFS",
+        "id": "5KpJ0jaMr0UusAxQ0R1RFS",
+        "name": "Wizard - Yellow Claw Remix",
+        "uri": "spotify:track:5KpJ0jaMr0UusAxQ0R1RFS",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/3UeAYPILU0r0fRhTp3FL9V",
+          "id": "3UeAYPILU0r0fRhTp3FL9V",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b27387b105a445ae69f7c4a8d480",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e0287b105a445ae69f7c4a8d480",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d0000485187b105a445ae69f7c4a8d480",
+              "width": 64
+            }
+          ],
+          "name": "Wizard (The Remixes)",
+          "release_date": "2014-03-31",
+          "release_date_precision": "day",
+          "uri": "spotify:album:3UeAYPILU0r0fRhTp3FL9V",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+              },
+              "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+              "id": "12SPNXi0aDpFt0rMVbmLrr",
+              "name": "Jay Hardway",
+              "type": "artist",
+              "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/3UeAYPILU0r0fRhTp3FL9V"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6ZXRsQeAoGPspf8tNeEtPo"
+            },
+            "href": "https://api.spotify.com/v1/artists/6ZXRsQeAoGPspf8tNeEtPo",
+            "id": "6ZXRsQeAoGPspf8tNeEtPo",
+            "name": "Tom & Jame",
+            "type": "artist",
+            "uri": "spotify:artist:6ZXRsQeAoGPspf8tNeEtPo"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 285000,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4x0tCd5ieoszWcv4XVOCBs"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4x0tCd5ieoszWcv4XVOCBs",
+        "id": "4x0tCd5ieoszWcv4XVOCBs",
+        "name": "Wizard - Tom & Jame Remix",
+        "uri": "spotify:track:4x0tCd5ieoszWcv4XVOCBs",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6PzXquldNYOf5zFoPO3ZsI",
+          "id": "6PzXquldNYOf5zFoPO3ZsI",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273998bfd2744a5532ce19b9a21",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02998bfd2744a5532ce19b9a21",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851998bfd2744a5532ce19b9a21",
+              "width": 64
+            }
+          ],
+          "name": "Helicopter",
+          "release_date": "2014-03-10",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6PzXquldNYOf5zFoPO3ZsI",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/53YSn9tHwGJ6bq5P0gGoYo"
+              },
+              "href": "https://api.spotify.com/v1/artists/53YSn9tHwGJ6bq5P0gGoYo",
+              "id": "53YSn9tHwGJ6bq5P0gGoYo",
+              "name": "Firebeatz",
+              "type": "artist",
+              "uri": "spotify:artist:53YSn9tHwGJ6bq5P0gGoYo"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6PzXquldNYOf5zFoPO3ZsI"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/53YSn9tHwGJ6bq5P0gGoYo"
+            },
+            "href": "https://api.spotify.com/v1/artists/53YSn9tHwGJ6bq5P0gGoYo",
+            "id": "53YSn9tHwGJ6bq5P0gGoYo",
+            "name": "Firebeatz",
+            "type": "artist",
+            "uri": "spotify:artist:53YSn9tHwGJ6bq5P0gGoYo"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 206449,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1toz8k7rYIw4FS5jOSXxYH"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1toz8k7rYIw4FS5jOSXxYH",
+        "id": "1toz8k7rYIw4FS5jOSXxYH",
+        "name": "Helicopter - Video Edit",
+        "uri": "spotify:track:1toz8k7rYIw4FS5jOSXxYH",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/4cLnteeIFyOB8TqAfyOISy",
+          "id": "4cLnteeIFyOB8TqAfyOISy",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a8bf95d447930d5e9d8de042",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a8bf95d447930d5e9d8de042",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a8bf95d447930d5e9d8de042",
+              "width": 64
+            }
+          ],
+          "name": "Proxy",
+          "release_date": "2014-03-07",
+          "release_date_precision": "day",
+          "uri": "spotify:album:4cLnteeIFyOB8TqAfyOISy",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/4cLnteeIFyOB8TqAfyOISy"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 279384,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0HSHOXIDMwhFbXHnaxpvxE"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0HSHOXIDMwhFbXHnaxpvxE",
+        "id": "0HSHOXIDMwhFbXHnaxpvxE",
+        "name": "Proxy - Original Mix",
+        "uri": "spotify:track:0HSHOXIDMwhFbXHnaxpvxE",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0N5QcojgdA6aP9oQ7yYG9A",
+          "id": "0N5QcojgdA6aP9oQ7yYG9A",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2738993223ca7b07fb866c1e605",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e028993223ca7b07fb866c1e605",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048518993223ca7b07fb866c1e605",
+              "width": 64
+            }
+          ],
+          "name": "Animals",
+          "release_date": "2013-07-01",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0N5QcojgdA6aP9oQ7yYG9A",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0N5QcojgdA6aP9oQ7yYG9A"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 304228,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0hv6ku4431kPrjbpBBspw3"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0hv6ku4431kPrjbpBBspw3",
+        "id": "0hv6ku4431kPrjbpBBspw3",
+        "name": "Animals - Original Mix",
+        "uri": "spotify:track:0hv6ku4431kPrjbpBBspw3",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6So837uOpZKUwnzrHViWCl",
+          "id": "6So837uOpZKUwnzrHViWCl",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ea88b073629bf4e91b2154",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ea88b073629bf4e91b2154",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ea88b073629bf4e91b2154",
+              "width": 64
+            }
+          ],
+          "name": "Animals (The Remixes Part 1)",
+          "release_date": "2014-01-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6So837uOpZKUwnzrHViWCl",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6So837uOpZKUwnzrHViWCl"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 262800,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/4XKQpjPdUcXuc1sGIu5cJ9"
+        },
+        "href": "https://api.spotify.com/v1/tracks/4XKQpjPdUcXuc1sGIu5cJ9",
+        "id": "4XKQpjPdUcXuc1sGIu5cJ9",
+        "name": "Animals - Oliver Heldens Remix",
+        "uri": "spotify:track:4XKQpjPdUcXuc1sGIu5cJ9",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6So837uOpZKUwnzrHViWCl",
+          "id": "6So837uOpZKUwnzrHViWCl",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ea88b073629bf4e91b2154",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ea88b073629bf4e91b2154",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ea88b073629bf4e91b2154",
+              "width": 64
+            }
+          ],
+          "name": "Animals (The Remixes Part 1)",
+          "release_date": "2014-01-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6So837uOpZKUwnzrHViWCl",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6So837uOpZKUwnzrHViWCl"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 2,
+        "duration_ms": 253090,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/3KXh5udmAP99e9Aznmd8Z6"
+        },
+        "href": "https://api.spotify.com/v1/tracks/3KXh5udmAP99e9Aznmd8Z6",
+        "id": "3KXh5udmAP99e9Aznmd8Z6",
+        "name": "Animals - Jay Ronko Remix",
+        "uri": "spotify:track:3KXh5udmAP99e9Aznmd8Z6",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6So837uOpZKUwnzrHViWCl",
+          "id": "6So837uOpZKUwnzrHViWCl",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ea88b073629bf4e91b2154",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ea88b073629bf4e91b2154",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ea88b073629bf4e91b2154",
+              "width": 64
+            }
+          ],
+          "name": "Animals (The Remixes Part 1)",
+          "release_date": "2014-01-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6So837uOpZKUwnzrHViWCl",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6So837uOpZKUwnzrHViWCl"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 3,
+        "duration_ms": 198466,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/448TLDGJXO7IP1VWRkD4kb"
+        },
+        "href": "https://api.spotify.com/v1/tracks/448TLDGJXO7IP1VWRkD4kb",
+        "id": "448TLDGJXO7IP1VWRkD4kb",
+        "name": "Animals - Victor Niglio & Martin Garrix Festival Trap Remix",
+        "uri": "spotify:track:448TLDGJXO7IP1VWRkD4kb",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6So837uOpZKUwnzrHViWCl",
+          "id": "6So837uOpZKUwnzrHViWCl",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273d5ea88b073629bf4e91b2154",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02d5ea88b073629bf4e91b2154",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851d5ea88b073629bf4e91b2154",
+              "width": 64
+            }
+          ],
+          "name": "Animals (The Remixes Part 1)",
+          "release_date": "2014-01-27",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6So837uOpZKUwnzrHViWCl",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6So837uOpZKUwnzrHViWCl"
+          },
+          "total_tracks": 4
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 4,
+        "duration_ms": 260625,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2CHORzlDWNpLgNsLvTOpgq"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2CHORzlDWNpLgNsLvTOpgq",
+        "id": "2CHORzlDWNpLgNsLvTOpgq",
+        "name": "Animals - Botnek Edit",
+        "uri": "spotify:track:2CHORzlDWNpLgNsLvTOpgq",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/1LUEJENeEAJdliMIDjauBx",
+          "id": "1LUEJENeEAJdliMIDjauBx",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2738840e1ce5be30ec35eacc929",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e028840e1ce5be30ec35eacc929",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048518840e1ce5be30ec35eacc929",
+              "width": 64
+            }
+          ],
+          "name": "Torrent",
+          "release_date": "2014-01-10",
+          "release_date_precision": "day",
+          "uri": "spotify:album:1LUEJENeEAJdliMIDjauBx",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XonXgjEAAXVl0WKLF1Z4g"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XonXgjEAAXVl0WKLF1Z4g",
+              "id": "3XonXgjEAAXVl0WKLF1Z4g",
+              "name": "Sidney Samson",
+              "type": "artist",
+              "uri": "spotify:artist:3XonXgjEAAXVl0WKLF1Z4g"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/1LUEJENeEAJdliMIDjauBx"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3XonXgjEAAXVl0WKLF1Z4g"
+            },
+            "href": "https://api.spotify.com/v1/artists/3XonXgjEAAXVl0WKLF1Z4g",
+            "id": "3XonXgjEAAXVl0WKLF1Z4g",
+            "name": "Sidney Samson",
+            "type": "artist",
+            "uri": "spotify:artist:3XonXgjEAAXVl0WKLF1Z4g"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 318754,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2zlq3jyBgKbiBMfmqU0x9F"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2zlq3jyBgKbiBMfmqU0x9F",
+        "id": "2zlq3jyBgKbiBMfmqU0x9F",
+        "name": "Torrent",
+        "uri": "spotify:track:2zlq3jyBgKbiBMfmqU0x9F",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "restrictions": {
+          "reason": "market"
+        },
+        "is_playable": false,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/24NKj9pKgI7RhIwUNTBJTM",
+          "id": "24NKj9pKgI7RhIwUNTBJTM",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273ca9f6afde4e52f9d0c726e70",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02ca9f6afde4e52f9d0c726e70",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851ca9f6afde4e52f9d0c726e70",
+              "width": 64
+            }
+          ],
+          "name": "Wizard Minimix (Spotify Exclusive)",
+          "release_date": "2013-12-02",
+          "release_date_precision": "day",
+          "uri": "spotify:album:24NKj9pKgI7RhIwUNTBJTM",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/24NKj9pKgI7RhIwUNTBJTM"
+          },
+          "total_tracks": 6
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 6,
+        "duration_ms": 574687,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1b4vmXsC3vqsCJTXliZ3B0"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1b4vmXsC3vqsCJTXliZ3B0",
+        "id": "1b4vmXsC3vqsCJTXliZ3B0",
+        "name": "Wizard Minimix",
+        "uri": "spotify:track:1b4vmXsC3vqsCJTXliZ3B0",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6DEpxu52B9Dypcu8pxFEDN",
+          "id": "6DEpxu52B9Dypcu8pxFEDN",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273696ef3ea38a4c56cf29905b2",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02696ef3ea38a4c56cf29905b2",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851696ef3ea38a4c56cf29905b2",
+              "width": 64
+            }
+          ],
+          "name": "Just Some Loops",
+          "release_date": "2013-06-14",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6DEpxu52B9Dypcu8pxFEDN",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/32Aw9aJJoXXC1Vn3zqzJbQ"
+              },
+              "href": "https://api.spotify.com/v1/artists/32Aw9aJJoXXC1Vn3zqzJbQ",
+              "id": "32Aw9aJJoXXC1Vn3zqzJbQ",
+              "name": "TV Noise",
+              "type": "artist",
+              "uri": "spotify:artist:32Aw9aJJoXXC1Vn3zqzJbQ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6DEpxu52B9Dypcu8pxFEDN"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/32Aw9aJJoXXC1Vn3zqzJbQ"
+            },
+            "href": "https://api.spotify.com/v1/artists/32Aw9aJJoXXC1Vn3zqzJbQ",
+            "id": "32Aw9aJJoXXC1Vn3zqzJbQ",
+            "name": "TV Noise",
+            "type": "artist",
+            "uri": "spotify:artist:32Aw9aJJoXXC1Vn3zqzJbQ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 303759,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/2qdg4xVXTmw7m1TUQd9x4e"
+        },
+        "href": "https://api.spotify.com/v1/tracks/2qdg4xVXTmw7m1TUQd9x4e",
+        "id": "2qdg4xVXTmw7m1TUQd9x4e",
+        "name": "Just Some Loops - Original Mix",
+        "uri": "spotify:track:2qdg4xVXTmw7m1TUQd9x4e",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/41Q52HSJVbtcG9IOtWeyHD",
+          "id": "41Q52HSJVbtcG9IOtWeyHD",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273a664e02bacc4b186ca106861",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02a664e02bacc4b186ca106861",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851a664e02bacc4b186ca106861",
+              "width": 64
+            }
+          ],
+          "name": "Error 404",
+          "release_date": "2013-03-18",
+          "release_date_precision": "day",
+          "uri": "spotify:album:41Q52HSJVbtcG9IOtWeyHD",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+              },
+              "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+              "id": "12SPNXi0aDpFt0rMVbmLrr",
+              "name": "Jay Hardway",
+              "type": "artist",
+              "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/41Q52HSJVbtcG9IOtWeyHD"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/12SPNXi0aDpFt0rMVbmLrr"
+            },
+            "href": "https://api.spotify.com/v1/artists/12SPNXi0aDpFt0rMVbmLrr",
+            "id": "12SPNXi0aDpFt0rMVbmLrr",
+            "name": "Jay Hardway",
+            "type": "artist",
+            "uri": "spotify:artist:12SPNXi0aDpFt0rMVbmLrr"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 333759,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/5c7UATnb0XfIbyIHHfgIMb"
+        },
+        "href": "https://api.spotify.com/v1/tracks/5c7UATnb0XfIbyIHHfgIMb",
+        "id": "5c7UATnb0XfIbyIHHfgIMb",
+        "name": "Error 404 - Original Mix",
+        "uri": "spotify:track:5c7UATnb0XfIbyIHHfgIMb",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/7xZak3wySwWlHuTn4eOzgD",
+          "id": "7xZak3wySwWlHuTn4eOzgD",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2733eb38fa488c90f89d457fdb4",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e023eb38fa488c90f89d457fdb4",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048513eb38fa488c90f89d457fdb4",
+              "width": 64
+            }
+          ],
+          "name": "BFAM",
+          "release_date": "2012-11-12",
+          "release_date_precision": "day",
+          "uri": "spotify:album:7xZak3wySwWlHuTn4eOzgD",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+              "id": "2vUCVkeZjzDcaoX4gagHdV",
+              "name": "Julian Jordan",
+              "type": "artist",
+              "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/7xZak3wySwWlHuTn4eOzgD"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+            },
+            "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+            "id": "2vUCVkeZjzDcaoX4gagHdV",
+            "name": "Julian Jordan",
+            "type": "artist",
+            "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 318794,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/0FN86CgJpiYHivPZ6ZlNm6"
+        },
+        "href": "https://api.spotify.com/v1/tracks/0FN86CgJpiYHivPZ6ZlNm6",
+        "id": "0FN86CgJpiYHivPZ6ZlNm6",
+        "name": "BFAM - Original Mix",
+        "uri": "spotify:track:0FN86CgJpiYHivPZ6ZlNm6",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/6EfCddoQmyeP1VngMBmgxZ",
+          "id": "6EfCddoQmyeP1VngMBmgxZ",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b273e28afd29db5ffedee37d7e42",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e02e28afd29db5ffedee37d7e42",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d00004851e28afd29db5ffedee37d7e42",
+              "width": 64
+            }
+          ],
+          "name": "Midnight Sun 2.0 (Martin Garrix Remix)",
+          "release_date": "2012-10-08",
+          "release_date_precision": "day",
+          "uri": "spotify:album:6EfCddoQmyeP1VngMBmgxZ",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/03RggOhzXgjvlFmc3A8TuW"
+              },
+              "href": "https://api.spotify.com/v1/artists/03RggOhzXgjvlFmc3A8TuW",
+              "id": "03RggOhzXgjvlFmc3A8TuW",
+              "name": "Roy Gates",
+              "type": "artist",
+              "uri": "spotify:artist:03RggOhzXgjvlFmc3A8TuW"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/6EfCddoQmyeP1VngMBmgxZ"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/03RggOhzXgjvlFmc3A8TuW"
+            },
+            "href": "https://api.spotify.com/v1/artists/03RggOhzXgjvlFmc3A8TuW",
+            "id": "03RggOhzXgjvlFmc3A8TuW",
+            "name": "Roy Gates",
+            "type": "artist",
+            "uri": "spotify:artist:03RggOhzXgjvlFmc3A8TuW"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 313129,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/6HD1Z5lx2SqHENf6NhsLr9"
+        },
+        "href": "https://api.spotify.com/v1/tracks/6HD1Z5lx2SqHENf6NhsLr9",
+        "id": "6HD1Z5lx2SqHENf6NhsLr9",
+        "name": "Midnight Sun 2.0 - Martin Garrix Remix",
+        "uri": "spotify:track:6HD1Z5lx2SqHENf6NhsLr9",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    },
+    {
+      "added_at": "2026-02-20T21:48:21Z",
+      "added_by": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "is_local": false,
+      "primary_color": null,
+      "item": {
+        "is_playable": true,
+        "explicit": false,
+        "type": "track",
+        "episode": false,
+        "track": true,
+        "album": {
+          "is_playable": true,
+          "type": "album",
+          "album_type": "single",
+          "href": "https://api.spotify.com/v1/albums/0qCFABkje7g5biVSmXOyOz",
+          "id": "0qCFABkje7g5biVSmXOyOz",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/ab67616d0000b2730c91dc72c2198609034f0ea5",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/ab67616d00001e020c91dc72c2198609034f0ea5",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/ab67616d000048510c91dc72c2198609034f0ea5",
+              "width": 64
+            }
+          ],
+          "name": "Keygen",
+          "release_date": "2012-09-03",
+          "release_date_precision": "day",
+          "uri": "spotify:album:0qCFABkje7g5biVSmXOyOz",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "external_urls": {
+            "spotify": "https://open.spotify.com/album/0qCFABkje7g5biVSmXOyOz"
+          },
+          "total_tracks": 1
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+            },
+            "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+            "id": "60d24wfXkVzDSfLS6hyCjZ",
+            "name": "Martin Garrix",
+            "type": "artist",
+            "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+          }
+        ],
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 296575,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/track/1UUdHRk0Bo4ssw1y2RCenI"
+        },
+        "href": "https://api.spotify.com/v1/tracks/1UUdHRk0Bo4ssw1y2RCenI",
+        "id": "1UUdHRk0Bo4ssw1y2RCenI",
+        "name": "Keygen - Original Mix",
+        "uri": "spotify:track:1UUdHRk0Bo4ssw1y2RCenI",
+        "is_local": false
+      },
+      "video_thumbnail": {
+        "url": null
+      }
+    }
+  ],
+  "limit": 100,
+  "next": null,
+  "offset": 200,
+  "previous": "https://api.spotify.com/v1/playlists/testId/items?offset=100&limit=100",
+  "total": 231
+}

--- a/tests/mock_fixtures/mocked_get_large_playlist_response.json
+++ b/tests/mock_fixtures/mocked_get_large_playlist_response.json
@@ -1,0 +1,12526 @@
+{
+  "collaborative": false,
+  "description": "",
+  "external_urls": {
+    "spotify": "https://open.spotify.com/playlist/testId"
+  },
+  "followers": {
+    "href": null,
+    "total": 0
+  },
+  "href": "https://api.spotify.com/v1/playlists/testId",
+  "id": "testId",
+  "images": [
+    {
+      "height": 640,
+      "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+      "width": 640
+    },
+    {
+      "height": 300,
+      "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+      "width": 300
+    },
+    {
+      "height": 60,
+      "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+      "width": 60
+    }
+  ],
+  "name": "test-playlist",
+  "owner": {
+    "display_name": "testUser",
+    "external_urls": {
+      "spotify": "https://open.spotify.com/user/testUser"
+    },
+    "href": "https://api.spotify.com/v1/users/testUser",
+    "id": "testUser",
+    "type": "user",
+    "uri": "spotify:user:testUser"
+  },
+  "primary_color": null,
+  "public": true,
+  "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+  "items": {
+    "href": "https://api.spotify.com/v1/playlists/testId/items?offset=0&limit=100",
+    "items": [
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6Gihz6RXvLYLFxHPMJC7nf",
+            "id": "6Gihz6RXvLYLFxHPMJC7nf",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27370969b566dd6d6646a6b42cb",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0270969b566dd6d6646a6b42cb",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485170969b566dd6d6646a6b42cb",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Ain't Letting You Down",
+            "release_date": "2025-10-24",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6Gihz6RXvLYLFxHPMJC7nf",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0v51lDHIlZBqe2F6yEeskF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0v51lDHIlZBqe2F6yEeskF",
+                "id": "0v51lDHIlZBqe2F6yEeskF",
+                "name": "Saksham",
+                "type": "artist",
+                "uri": "spotify:artist:0v51lDHIlZBqe2F6yEeskF"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0FlBLkbHEvmCMu2X46Ail1"
+                },
+                "href": "https://api.spotify.com/v1/artists/0FlBLkbHEvmCMu2X46Ail1",
+                "id": "0FlBLkbHEvmCMu2X46Ail1",
+                "name": "Scott Quinn",
+                "type": "artist",
+                "uri": "spotify:artist:0FlBLkbHEvmCMu2X46Ail1"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6Gihz6RXvLYLFxHPMJC7nf"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0v51lDHIlZBqe2F6yEeskF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0v51lDHIlZBqe2F6yEeskF",
+              "id": "0v51lDHIlZBqe2F6yEeskF",
+              "name": "Saksham",
+              "type": "artist",
+              "uri": "spotify:artist:0v51lDHIlZBqe2F6yEeskF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0FlBLkbHEvmCMu2X46Ail1"
+              },
+              "href": "https://api.spotify.com/v1/artists/0FlBLkbHEvmCMu2X46Ail1",
+              "id": "0FlBLkbHEvmCMu2X46Ail1",
+              "name": "Scott Quinn",
+              "type": "artist",
+              "uri": "spotify:artist:0FlBLkbHEvmCMu2X46Ail1"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 261958,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1vQolNYci1yfPZccu6mqIB"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1vQolNYci1yfPZccu6mqIB",
+          "id": "1vQolNYci1yfPZccu6mqIB",
+          "name": "Ain't Letting You Down",
+          "uri": "spotify:track:1vQolNYci1yfPZccu6mqIB",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0e1KpmhEst3f1TPw8xJY8S",
+            "id": "0e1KpmhEst3f1TPw8xJY8S",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273654151030adcbda019dcba22",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02654151030adcbda019dcba22",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851654151030adcbda019dcba22",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Butterflies",
+            "release_date": "2025-09-26",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0e1KpmhEst3f1TPw8xJY8S",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0I570b72DF4WXlk8zcKaPc"
+                },
+                "href": "https://api.spotify.com/v1/artists/0I570b72DF4WXlk8zcKaPc",
+                "id": "0I570b72DF4WXlk8zcKaPc",
+                "name": "BARBZ",
+                "type": "artist",
+                "uri": "spotify:artist:0I570b72DF4WXlk8zcKaPc"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0e1KpmhEst3f1TPw8xJY8S"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0I570b72DF4WXlk8zcKaPc"
+              },
+              "href": "https://api.spotify.com/v1/artists/0I570b72DF4WXlk8zcKaPc",
+              "id": "0I570b72DF4WXlk8zcKaPc",
+              "name": "BARBZ",
+              "type": "artist",
+              "uri": "spotify:artist:0I570b72DF4WXlk8zcKaPc"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 227735,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/129zR3hX9D2BYXOMtk2jaT"
+          },
+          "href": "https://api.spotify.com/v1/tracks/129zR3hX9D2BYXOMtk2jaT",
+          "id": "129zR3hX9D2BYXOMtk2jaT",
+          "name": "⁠⁠Butterflies",
+          "uri": "spotify:track:129zR3hX9D2BYXOMtk2jaT",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0JnmszyYOgIIF7x4GLILSM",
+            "id": "0JnmszyYOgIIF7x4GLILSM",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2735463877b909d6eaf35e27d96",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e025463877b909d6eaf35e27d96",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048515463877b909d6eaf35e27d96",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Voodoo",
+            "release_date": "2025-09-19",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0JnmszyYOgIIF7x4GLILSM",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6cEuCEZu7PAE9ZSzLLc2oQ"
+                },
+                "href": "https://api.spotify.com/v1/artists/6cEuCEZu7PAE9ZSzLLc2oQ",
+                "id": "6cEuCEZu7PAE9ZSzLLc2oQ",
+                "name": "R3HAB",
+                "type": "artist",
+                "uri": "spotify:artist:6cEuCEZu7PAE9ZSzLLc2oQ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4CrDEHL7ysNabeYvL3xjUX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4CrDEHL7ysNabeYvL3xjUX",
+                "id": "4CrDEHL7ysNabeYvL3xjUX",
+                "name": "Skytech",
+                "type": "artist",
+                "uri": "spotify:artist:4CrDEHL7ysNabeYvL3xjUX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0JnmszyYOgIIF7x4GLILSM"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6cEuCEZu7PAE9ZSzLLc2oQ"
+              },
+              "href": "https://api.spotify.com/v1/artists/6cEuCEZu7PAE9ZSzLLc2oQ",
+              "id": "6cEuCEZu7PAE9ZSzLLc2oQ",
+              "name": "R3HAB",
+              "type": "artist",
+              "uri": "spotify:artist:6cEuCEZu7PAE9ZSzLLc2oQ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4CrDEHL7ysNabeYvL3xjUX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4CrDEHL7ysNabeYvL3xjUX",
+              "id": "4CrDEHL7ysNabeYvL3xjUX",
+              "name": "Skytech",
+              "type": "artist",
+              "uri": "spotify:artist:4CrDEHL7ysNabeYvL3xjUX"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 169326,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7sKCIyN4Sdeo7OBBUeMCfy"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7sKCIyN4Sdeo7OBBUeMCfy",
+          "id": "7sKCIyN4Sdeo7OBBUeMCfy",
+          "name": "Voodoo",
+          "uri": "spotify:track:7sKCIyN4Sdeo7OBBUeMCfy",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/28YMaSE5kx5tM9HpdafuCh",
+            "id": "28YMaSE5kx5tM9HpdafuCh",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273ebcfc84442b172f6291a3b74",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ebcfc84442b172f6291a3b74",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851ebcfc84442b172f6291a3b74",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Peace of Flood",
+            "release_date": "2025-09-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:28YMaSE5kx5tM9HpdafuCh",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6hyMWrxGBsOx6sWcVj1DqP"
+                },
+                "href": "https://api.spotify.com/v1/artists/6hyMWrxGBsOx6sWcVj1DqP",
+                "id": "6hyMWrxGBsOx6sWcVj1DqP",
+                "name": "Sebastian Ingrosso",
+                "type": "artist",
+                "uri": "spotify:artist:6hyMWrxGBsOx6sWcVj1DqP"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6Mek67pKmBw5N3FZnAc2J8"
+                },
+                "href": "https://api.spotify.com/v1/artists/6Mek67pKmBw5N3FZnAc2J8",
+                "id": "6Mek67pKmBw5N3FZnAc2J8",
+                "name": "Citadelle",
+                "type": "artist",
+                "uri": "spotify:artist:6Mek67pKmBw5N3FZnAc2J8"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/28YMaSE5kx5tM9HpdafuCh"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6hyMWrxGBsOx6sWcVj1DqP"
+              },
+              "href": "https://api.spotify.com/v1/artists/6hyMWrxGBsOx6sWcVj1DqP",
+              "id": "6hyMWrxGBsOx6sWcVj1DqP",
+              "name": "Sebastian Ingrosso",
+              "type": "artist",
+              "uri": "spotify:artist:6hyMWrxGBsOx6sWcVj1DqP"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6Mek67pKmBw5N3FZnAc2J8"
+              },
+              "href": "https://api.spotify.com/v1/artists/6Mek67pKmBw5N3FZnAc2J8",
+              "id": "6Mek67pKmBw5N3FZnAc2J8",
+              "name": "Citadelle",
+              "type": "artist",
+              "uri": "spotify:artist:6Mek67pKmBw5N3FZnAc2J8"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 293146,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/70LDxWCoJKuxpgtErYHDQb"
+          },
+          "href": "https://api.spotify.com/v1/tracks/70LDxWCoJKuxpgtErYHDQb",
+          "id": "70LDxWCoJKuxpgtErYHDQb",
+          "name": "Peace of Flood",
+          "uri": "spotify:track:70LDxWCoJKuxpgtErYHDQb",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/4obbdNRvSbjPA4FmO76mcu",
+            "id": "4obbdNRvSbjPA4FmO76mcu",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2730c4bfbffbe4e2d61fb70d935",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e020c4bfbffbe4e2d61fb70d935",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048510c4bfbffbe4e2d61fb70d935",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "MAD (Matt Pridgyn Remix)",
+            "release_date": "2025-09-05",
+            "release_date_precision": "day",
+            "uri": "spotify:album:4obbdNRvSbjPA4FmO76mcu",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5JZ7CnR6gTvEMKX4g70Amv"
+                },
+                "href": "https://api.spotify.com/v1/artists/5JZ7CnR6gTvEMKX4g70Amv",
+                "id": "5JZ7CnR6gTvEMKX4g70Amv",
+                "name": "Lauv",
+                "type": "artist",
+                "uri": "spotify:artist:5JZ7CnR6gTvEMKX4g70Amv"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2RZVfmCJEK0AJ9JJ7Bphlu"
+                },
+                "href": "https://api.spotify.com/v1/artists/2RZVfmCJEK0AJ9JJ7Bphlu",
+                "id": "2RZVfmCJEK0AJ9JJ7Bphlu",
+                "name": "Matt Pridgyn",
+                "type": "artist",
+                "uri": "spotify:artist:2RZVfmCJEK0AJ9JJ7Bphlu"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/4obbdNRvSbjPA4FmO76mcu"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5JZ7CnR6gTvEMKX4g70Amv"
+              },
+              "href": "https://api.spotify.com/v1/artists/5JZ7CnR6gTvEMKX4g70Amv",
+              "id": "5JZ7CnR6gTvEMKX4g70Amv",
+              "name": "Lauv",
+              "type": "artist",
+              "uri": "spotify:artist:5JZ7CnR6gTvEMKX4g70Amv"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2RZVfmCJEK0AJ9JJ7Bphlu"
+              },
+              "href": "https://api.spotify.com/v1/artists/2RZVfmCJEK0AJ9JJ7Bphlu",
+              "id": "2RZVfmCJEK0AJ9JJ7Bphlu",
+              "name": "Matt Pridgyn",
+              "type": "artist",
+              "uri": "spotify:artist:2RZVfmCJEK0AJ9JJ7Bphlu"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 206250,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6k99wxsDKgFMyvCBRIWLtl"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6k99wxsDKgFMyvCBRIWLtl",
+          "id": "6k99wxsDKgFMyvCBRIWLtl",
+          "name": "MAD - Matt Pridgyn Remix",
+          "uri": "spotify:track:6k99wxsDKgFMyvCBRIWLtl",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1duRCWQVzDQXiM5PVHcXVF",
+            "id": "1duRCWQVzDQXiM5PVHcXVF",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273485c12dbdcb35cb9c0c55804",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02485c12dbdcb35cb9c0c55804",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851485c12dbdcb35cb9c0c55804",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Set Me Free",
+            "release_date": "2025-08-22",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1duRCWQVzDQXiM5PVHcXVF",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0ycvq8upLhNmddPdQXhLOy"
+                },
+                "href": "https://api.spotify.com/v1/artists/0ycvq8upLhNmddPdQXhLOy",
+                "id": "0ycvq8upLhNmddPdQXhLOy",
+                "name": "Arcando",
+                "type": "artist",
+                "uri": "spotify:artist:0ycvq8upLhNmddPdQXhLOy"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+                },
+                "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+                "id": "7Io0XduXk7aOHFHA7sLru2",
+                "name": "Bonn",
+                "type": "artist",
+                "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1duRCWQVzDQXiM5PVHcXVF"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0ycvq8upLhNmddPdQXhLOy"
+              },
+              "href": "https://api.spotify.com/v1/artists/0ycvq8upLhNmddPdQXhLOy",
+              "id": "0ycvq8upLhNmddPdQXhLOy",
+              "name": "Arcando",
+              "type": "artist",
+              "uri": "spotify:artist:0ycvq8upLhNmddPdQXhLOy"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 189176,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1tIYTeCrLtHTbZwmKXh625"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1tIYTeCrLtHTbZwmKXh625",
+          "id": "1tIYTeCrLtHTbZwmKXh625",
+          "name": "Set Me Free",
+          "uri": "spotify:track:1tIYTeCrLtHTbZwmKXh625",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7oqrJHKyfWOJGJqLSG4iDW",
+            "id": "7oqrJHKyfWOJGJqLSG4iDW",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2738e67cf2fff092dbc66935875",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e028e67cf2fff092dbc66935875",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048518e67cf2fff092dbc66935875",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Sleepless Nights",
+            "release_date": "2025-08-08",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7oqrJHKyfWOJGJqLSG4iDW",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0SfsnGyD8FpIN4U4WCkBZ5"
+                },
+                "href": "https://api.spotify.com/v1/artists/0SfsnGyD8FpIN4U4WCkBZ5",
+                "id": "0SfsnGyD8FpIN4U4WCkBZ5",
+                "name": "Armin van Buuren",
+                "type": "artist",
+                "uri": "spotify:artist:0SfsnGyD8FpIN4U4WCkBZ5"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0myPBTBG3ODlKVBEf5OSBe"
+                },
+                "href": "https://api.spotify.com/v1/artists/0myPBTBG3ODlKVBEf5OSBe",
+                "id": "0myPBTBG3ODlKVBEf5OSBe",
+                "name": "Libby Whitehouse",
+                "type": "artist",
+                "uri": "spotify:artist:0myPBTBG3ODlKVBEf5OSBe"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7oqrJHKyfWOJGJqLSG4iDW"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0SfsnGyD8FpIN4U4WCkBZ5"
+              },
+              "href": "https://api.spotify.com/v1/artists/0SfsnGyD8FpIN4U4WCkBZ5",
+              "id": "0SfsnGyD8FpIN4U4WCkBZ5",
+              "name": "Armin van Buuren",
+              "type": "artist",
+              "uri": "spotify:artist:0SfsnGyD8FpIN4U4WCkBZ5"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0myPBTBG3ODlKVBEf5OSBe"
+              },
+              "href": "https://api.spotify.com/v1/artists/0myPBTBG3ODlKVBEf5OSBe",
+              "id": "0myPBTBG3ODlKVBEf5OSBe",
+              "name": "Libby Whitehouse",
+              "type": "artist",
+              "uri": "spotify:artist:0myPBTBG3ODlKVBEf5OSBe"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 180422,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/39pgWHKvgtSlvEI0AWvi62"
+          },
+          "href": "https://api.spotify.com/v1/tracks/39pgWHKvgtSlvEI0AWvi62",
+          "id": "39pgWHKvgtSlvEI0AWvi62",
+          "name": "Sleepless Nights",
+          "uri": "spotify:track:39pgWHKvgtSlvEI0AWvi62",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1pUTJrfFFnXTWsyKe1Ixyh",
+            "id": "1pUTJrfFFnXTWsyKe1Ixyh",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2737de2b488887bcc37ed4fbac2",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e027de2b488887bcc37ed4fbac2",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048517de2b488887bcc37ed4fbac2",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Inside Our Hearts",
+            "release_date": "2025-07-25",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1pUTJrfFFnXTWsyKe1Ixyh",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4AVFqumd2ogHFlRbKIjp1t"
+                },
+                "href": "https://api.spotify.com/v1/artists/4AVFqumd2ogHFlRbKIjp1t",
+                "id": "4AVFqumd2ogHFlRbKIjp1t",
+                "name": "Alesso",
+                "type": "artist",
+                "uri": "spotify:artist:4AVFqumd2ogHFlRbKIjp1t"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+                },
+                "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+                "id": "4ukUyiEoZi8QxibfjuUsEw",
+                "name": "Shaun Farrugia",
+                "type": "artist",
+                "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1pUTJrfFFnXTWsyKe1Ixyh"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4AVFqumd2ogHFlRbKIjp1t"
+              },
+              "href": "https://api.spotify.com/v1/artists/4AVFqumd2ogHFlRbKIjp1t",
+              "id": "4AVFqumd2ogHFlRbKIjp1t",
+              "name": "Alesso",
+              "type": "artist",
+              "uri": "spotify:artist:4AVFqumd2ogHFlRbKIjp1t"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+              },
+              "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+              "id": "4ukUyiEoZi8QxibfjuUsEw",
+              "name": "Shaun Farrugia",
+              "type": "artist",
+              "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 234086,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7JxHc4FNqdIzIJyrpqYAdH"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7JxHc4FNqdIzIJyrpqYAdH",
+          "id": "7JxHc4FNqdIzIJyrpqYAdH",
+          "name": "Inside Our Hearts",
+          "uri": "spotify:track:7JxHc4FNqdIzIJyrpqYAdH",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1R0CAZwCU6rRvMsmaerCjz",
+            "id": "1R0CAZwCU6rRvMsmaerCjz",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733fc9e6b9a43f9b7d6f703576",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023fc9e6b9a43f9b7d6f703576",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513fc9e6b9a43f9b7d6f703576",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Our Time",
+            "release_date": "2025-07-11",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1R0CAZwCU6rRvMsmaerCjz",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4D75GcNG95ebPtNvoNVXhz"
+                },
+                "href": "https://api.spotify.com/v1/artists/4D75GcNG95ebPtNvoNVXhz",
+                "id": "4D75GcNG95ebPtNvoNVXhz",
+                "name": "AFROJACK",
+                "type": "artist",
+                "uri": "spotify:artist:4D75GcNG95ebPtNvoNVXhz"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+                },
+                "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+                "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+                "name": "David Guetta",
+                "type": "artist",
+                "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6OHd6Z5k9ZmBJ91oqeSpDG"
+                },
+                "href": "https://api.spotify.com/v1/artists/6OHd6Z5k9ZmBJ91oqeSpDG",
+                "id": "6OHd6Z5k9ZmBJ91oqeSpDG",
+                "name": "Amél",
+                "type": "artist",
+                "uri": "spotify:artist:6OHd6Z5k9ZmBJ91oqeSpDG"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1R0CAZwCU6rRvMsmaerCjz"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4D75GcNG95ebPtNvoNVXhz"
+              },
+              "href": "https://api.spotify.com/v1/artists/4D75GcNG95ebPtNvoNVXhz",
+              "id": "4D75GcNG95ebPtNvoNVXhz",
+              "name": "AFROJACK",
+              "type": "artist",
+              "uri": "spotify:artist:4D75GcNG95ebPtNvoNVXhz"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+              },
+              "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+              "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+              "name": "David Guetta",
+              "type": "artist",
+              "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6OHd6Z5k9ZmBJ91oqeSpDG"
+              },
+              "href": "https://api.spotify.com/v1/artists/6OHd6Z5k9ZmBJ91oqeSpDG",
+              "id": "6OHd6Z5k9ZmBJ91oqeSpDG",
+              "name": "Amél",
+              "type": "artist",
+              "uri": "spotify:artist:6OHd6Z5k9ZmBJ91oqeSpDG"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 161367,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3MUFebos5drIwrUHxUorhP"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3MUFebos5drIwrUHxUorhP",
+          "id": "3MUFebos5drIwrUHxUorhP",
+          "name": "Our Time",
+          "uri": "spotify:track:3MUFebos5drIwrUHxUorhP",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/22V3MT04FxMnr8RxzhbIve",
+            "id": "22V3MT04FxMnr8RxzhbIve",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273584493d8b98920efd412f0c0",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02584493d8b98920efd412f0c0",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851584493d8b98920efd412f0c0",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Peace Of Mind",
+            "release_date": "2025-06-27",
+            "release_date_precision": "day",
+            "uri": "spotify:album:22V3MT04FxMnr8RxzhbIve",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6Mek67pKmBw5N3FZnAc2J8"
+                },
+                "href": "https://api.spotify.com/v1/artists/6Mek67pKmBw5N3FZnAc2J8",
+                "id": "6Mek67pKmBw5N3FZnAc2J8",
+                "name": "Citadelle",
+                "type": "artist",
+                "uri": "spotify:artist:6Mek67pKmBw5N3FZnAc2J8"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/22V3MT04FxMnr8RxzhbIve"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6Mek67pKmBw5N3FZnAc2J8"
+              },
+              "href": "https://api.spotify.com/v1/artists/6Mek67pKmBw5N3FZnAc2J8",
+              "id": "6Mek67pKmBw5N3FZnAc2J8",
+              "name": "Citadelle",
+              "type": "artist",
+              "uri": "spotify:artist:6Mek67pKmBw5N3FZnAc2J8"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 148214,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1Ju9Tb5R1vsUu1Ir8sO6vX"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1Ju9Tb5R1vsUu1Ir8sO6vX",
+          "id": "1Ju9Tb5R1vsUu1Ir8sO6vX",
+          "name": "Peace Of Mind",
+          "uri": "spotify:track:1Ju9Tb5R1vsUu1Ir8sO6vX",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6e3hxK9NnMP08e6GBC1WIV",
+            "id": "6e3hxK9NnMP08e6GBC1WIV",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2735c0e5abe73559c2de9d2eee0",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e025c0e5abe73559c2de9d2eee0",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048515c0e5abe73559c2de9d2eee0",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "MAD",
+            "release_date": "2025-05-27",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6e3hxK9NnMP08e6GBC1WIV",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5JZ7CnR6gTvEMKX4g70Amv"
+                },
+                "href": "https://api.spotify.com/v1/artists/5JZ7CnR6gTvEMKX4g70Amv",
+                "id": "5JZ7CnR6gTvEMKX4g70Amv",
+                "name": "Lauv",
+                "type": "artist",
+                "uri": "spotify:artist:5JZ7CnR6gTvEMKX4g70Amv"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6e3hxK9NnMP08e6GBC1WIV"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5JZ7CnR6gTvEMKX4g70Amv"
+              },
+              "href": "https://api.spotify.com/v1/artists/5JZ7CnR6gTvEMKX4g70Amv",
+              "id": "5JZ7CnR6gTvEMKX4g70Amv",
+              "name": "Lauv",
+              "type": "artist",
+              "uri": "spotify:artist:5JZ7CnR6gTvEMKX4g70Amv"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 199804,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6vM1GSndPtQk7AmqEmNAPH"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6vM1GSndPtQk7AmqEmNAPH",
+          "id": "6vM1GSndPtQk7AmqEmNAPH",
+          "name": "MAD",
+          "uri": "spotify:track:6vM1GSndPtQk7AmqEmNAPH",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1hRQTykXLhpCU8QGBLWVh8",
+            "id": "1hRQTykXLhpCU8QGBLWVh8",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2734f9b5941cfd6cf5c95992772",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e024f9b5941cfd6cf5c95992772",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048514f9b5941cfd6cf5c95992772",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Weightless",
+            "release_date": "2025-04-11",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1hRQTykXLhpCU8QGBLWVh8",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4YRxDV8wJFPHPTeXepOstw"
+                },
+                "href": "https://api.spotify.com/v1/artists/4YRxDV8wJFPHPTeXepOstw",
+                "id": "4YRxDV8wJFPHPTeXepOstw",
+                "name": "Arijit Singh",
+                "type": "artist",
+                "uri": "spotify:artist:4YRxDV8wJFPHPTeXepOstw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1hRQTykXLhpCU8QGBLWVh8"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4YRxDV8wJFPHPTeXepOstw"
+              },
+              "href": "https://api.spotify.com/v1/artists/4YRxDV8wJFPHPTeXepOstw",
+              "id": "4YRxDV8wJFPHPTeXepOstw",
+              "name": "Arijit Singh",
+              "type": "artist",
+              "uri": "spotify:artist:4YRxDV8wJFPHPTeXepOstw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 222701,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3ZDr3LJNCHailBSkpc29SF"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3ZDr3LJNCHailBSkpc29SF",
+          "id": "3ZDr3LJNCHailBSkpc29SF",
+          "name": "Weightless",
+          "uri": "spotify:track:3ZDr3LJNCHailBSkpc29SF",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1bOANBDFMPylV75pmNK4l3",
+            "id": "1bOANBDFMPylV75pmNK4l3",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27388b7d5b6118538683d9082d0",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0288b7d5b6118538683d9082d0",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485188b7d5b6118538683d9082d0",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Angels For Each Other",
+            "release_date": "2025-03-13",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1bOANBDFMPylV75pmNK4l3",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4YRxDV8wJFPHPTeXepOstw"
+                },
+                "href": "https://api.spotify.com/v1/artists/4YRxDV8wJFPHPTeXepOstw",
+                "id": "4YRxDV8wJFPHPTeXepOstw",
+                "name": "Arijit Singh",
+                "type": "artist",
+                "uri": "spotify:artist:4YRxDV8wJFPHPTeXepOstw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1bOANBDFMPylV75pmNK4l3"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4YRxDV8wJFPHPTeXepOstw"
+              },
+              "href": "https://api.spotify.com/v1/artists/4YRxDV8wJFPHPTeXepOstw",
+              "id": "4YRxDV8wJFPHPTeXepOstw",
+              "name": "Arijit Singh",
+              "type": "artist",
+              "uri": "spotify:artist:4YRxDV8wJFPHPTeXepOstw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 215076,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7KPcippmg9MvPzb3dzNpQW"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7KPcippmg9MvPzb3dzNpQW",
+          "id": "7KPcippmg9MvPzb3dzNpQW",
+          "name": "Angels For Each Other",
+          "uri": "spotify:track:7KPcippmg9MvPzb3dzNpQW",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3peq5CPlvCF11LKMDN4k8H",
+            "id": "3peq5CPlvCF11LKMDN4k8H",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27374ed367a3007b962487f89bb",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0274ed367a3007b962487f89bb",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485174ed367a3007b962487f89bb",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So",
+            "release_date": "2024-11-22",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3peq5CPlvCF11LKMDN4k8H",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3peq5CPlvCF11LKMDN4k8H"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 187031,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/52dEZA0A4siRTuA4e8w3ll"
+          },
+          "href": "https://api.spotify.com/v1/tracks/52dEZA0A4siRTuA4e8w3ll",
+          "id": "52dEZA0A4siRTuA4e8w3ll",
+          "name": "Told You So",
+          "uri": "spotify:track:52dEZA0A4siRTuA4e8w3ll",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7tSdlRlODwsNkMHTT86VCY",
+            "id": "7tSdlRlODwsNkMHTT86VCY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2736792be97219e930a685a1ce8",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e026792be97219e930a685a1ce8",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048516792be97219e930a685a1ce8",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 2)",
+            "release_date": "2025-01-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7tSdlRlODwsNkMHTT86VCY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7tSdlRlODwsNkMHTT86VCY"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6IoO8i8OnEodMtJ3CFKlAH"
+              },
+              "href": "https://api.spotify.com/v1/artists/6IoO8i8OnEodMtJ3CFKlAH",
+              "id": "6IoO8i8OnEodMtJ3CFKlAH",
+              "name": "Vidojean X Oliver Loenn",
+              "type": "artist",
+              "uri": "spotify:artist:6IoO8i8OnEodMtJ3CFKlAH"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 193500,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2omcVXez644eD6JRKIDqeH"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2omcVXez644eD6JRKIDqeH",
+          "id": "2omcVXez644eD6JRKIDqeH",
+          "name": "Told You So - Vidojean X Oliver Loenn Remix",
+          "uri": "spotify:track:2omcVXez644eD6JRKIDqeH",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3ZNDcJGZGcIge6HPMGos3X",
+            "id": "3ZNDcJGZGcIge6HPMGos3X",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2730914738d84e37c09828dd0f2",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e020914738d84e37c09828dd0f2",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048510914738d84e37c09828dd0f2",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 1)",
+            "release_date": "2025-01-03",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3ZNDcJGZGcIge6HPMGos3X",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3ZNDcJGZGcIge6HPMGos3X"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/03y4yOxhLk6MDJ1bV424uO"
+              },
+              "href": "https://api.spotify.com/v1/artists/03y4yOxhLk6MDJ1bV424uO",
+              "id": "03y4yOxhLk6MDJ1bV424uO",
+              "name": "Lavern",
+              "type": "artist",
+              "uri": "spotify:artist:03y4yOxhLk6MDJ1bV424uO"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5mOO1KIfKb5HY8ieKjG9Qf"
+              },
+              "href": "https://api.spotify.com/v1/artists/5mOO1KIfKb5HY8ieKjG9Qf",
+              "id": "5mOO1KIfKb5HY8ieKjG9Qf",
+              "name": "VisionV",
+              "type": "artist",
+              "uri": "spotify:artist:5mOO1KIfKb5HY8ieKjG9Qf"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 150461,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7sq5lP2gH7lR6EiiyhEbNt"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7sq5lP2gH7lR6EiiyhEbNt",
+          "id": "7sq5lP2gH7lR6EiiyhEbNt",
+          "name": "Told You So - Lavern & VisionV Remix",
+          "uri": "spotify:track:7sq5lP2gH7lR6EiiyhEbNt",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7tSdlRlODwsNkMHTT86VCY",
+            "id": "7tSdlRlODwsNkMHTT86VCY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2736792be97219e930a685a1ce8",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e026792be97219e930a685a1ce8",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048516792be97219e930a685a1ce8",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 2)",
+            "release_date": "2025-01-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7tSdlRlODwsNkMHTT86VCY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7tSdlRlODwsNkMHTT86VCY"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6Jbyd4qzEtbFtswZP1o6Ht"
+              },
+              "href": "https://api.spotify.com/v1/artists/6Jbyd4qzEtbFtswZP1o6Ht",
+              "id": "6Jbyd4qzEtbFtswZP1o6Ht",
+              "name": "Agents Of Time",
+              "type": "artist",
+              "uri": "spotify:artist:6Jbyd4qzEtbFtswZP1o6Ht"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 221102,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2lQnyDTZSKQEgPYZtXYMaV"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2lQnyDTZSKQEgPYZtXYMaV",
+          "id": "2lQnyDTZSKQEgPYZtXYMaV",
+          "name": "Told You So - Agents Of Time Remix",
+          "uri": "spotify:track:2lQnyDTZSKQEgPYZtXYMaV",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7tSdlRlODwsNkMHTT86VCY",
+            "id": "7tSdlRlODwsNkMHTT86VCY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2736792be97219e930a685a1ce8",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e026792be97219e930a685a1ce8",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048516792be97219e930a685a1ce8",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 2)",
+            "release_date": "2025-01-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7tSdlRlODwsNkMHTT86VCY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7tSdlRlODwsNkMHTT86VCY"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4CrDEHL7ysNabeYvL3xjUX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4CrDEHL7ysNabeYvL3xjUX",
+              "id": "4CrDEHL7ysNabeYvL3xjUX",
+              "name": "Skytech",
+              "type": "artist",
+              "uri": "spotify:artist:4CrDEHL7ysNabeYvL3xjUX"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 138750,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3zogSHoJaZdv8Q84nyWB2T"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3zogSHoJaZdv8Q84nyWB2T",
+          "id": "3zogSHoJaZdv8Q84nyWB2T",
+          "name": "Told You So - Skytech Remix",
+          "uri": "spotify:track:3zogSHoJaZdv8Q84nyWB2T",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7tSdlRlODwsNkMHTT86VCY",
+            "id": "7tSdlRlODwsNkMHTT86VCY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2736792be97219e930a685a1ce8",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e026792be97219e930a685a1ce8",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048516792be97219e930a685a1ce8",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 2)",
+            "release_date": "2025-01-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7tSdlRlODwsNkMHTT86VCY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7tSdlRlODwsNkMHTT86VCY"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/43goRyUiLUUbt0QXpfcU8p"
+              },
+              "href": "https://api.spotify.com/v1/artists/43goRyUiLUUbt0QXpfcU8p",
+              "id": "43goRyUiLUUbt0QXpfcU8p",
+              "name": "Merow",
+              "type": "artist",
+              "uri": "spotify:artist:43goRyUiLUUbt0QXpfcU8p"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 4,
+          "duration_ms": 223593,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4vW5JZsSMbCSIQvUskqkb9"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4vW5JZsSMbCSIQvUskqkb9",
+          "id": "4vW5JZsSMbCSIQvUskqkb9",
+          "name": "Told You So - Merow Remix",
+          "uri": "spotify:track:4vW5JZsSMbCSIQvUskqkb9",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3ZNDcJGZGcIge6HPMGos3X",
+            "id": "3ZNDcJGZGcIge6HPMGos3X",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2730914738d84e37c09828dd0f2",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e020914738d84e37c09828dd0f2",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048510914738d84e37c09828dd0f2",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 1)",
+            "release_date": "2025-01-03",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3ZNDcJGZGcIge6HPMGos3X",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3ZNDcJGZGcIge6HPMGos3X"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 183862,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5IGNejaPwvIGHFulOKRvVp"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5IGNejaPwvIGHFulOKRvVp",
+          "id": "5IGNejaPwvIGHFulOKRvVp",
+          "name": "Told You So - Brooks Remix",
+          "uri": "spotify:track:5IGNejaPwvIGHFulOKRvVp",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3ZNDcJGZGcIge6HPMGos3X",
+            "id": "3ZNDcJGZGcIge6HPMGos3X",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2730914738d84e37c09828dd0f2",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e020914738d84e37c09828dd0f2",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048510914738d84e37c09828dd0f2",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Remixes Vol. 1)",
+            "release_date": "2025-01-03",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3ZNDcJGZGcIge6HPMGos3X",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3ZNDcJGZGcIge6HPMGos3X"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/64wwBeRlMZenhRspSoRSqR"
+              },
+              "href": "https://api.spotify.com/v1/artists/64wwBeRlMZenhRspSoRSqR",
+              "id": "64wwBeRlMZenhRspSoRSqR",
+              "name": "Nova Blue",
+              "type": "artist",
+              "uri": "spotify:artist:64wwBeRlMZenhRspSoRSqR"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 155231,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/46aw03kRKdxGO5t5GJAtLA"
+          },
+          "href": "https://api.spotify.com/v1/tracks/46aw03kRKdxGO5t5GJAtLA",
+          "id": "46aw03kRKdxGO5t5GJAtLA",
+          "name": "Told You So - Nova Blue Remix",
+          "uri": "spotify:track:46aw03kRKdxGO5t5GJAtLA",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3ROJjwTulQSpaUtgXgpKAu",
+            "id": "3ROJjwTulQSpaUtgXgpKAu",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27341266c956e2fcdfc1dde4e16",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0241266c956e2fcdfc1dde4e16",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485141266c956e2fcdfc1dde4e16",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Told You So (Acoustic Version)",
+            "release_date": "2025-02-14",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3ROJjwTulQSpaUtgXgpKAu",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+                "id": "0NO8SsF6umjI3iQJzTycVF",
+                "name": "Jex",
+                "type": "artist",
+                "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3ROJjwTulQSpaUtgXgpKAu"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NO8SsF6umjI3iQJzTycVF"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NO8SsF6umjI3iQJzTycVF",
+              "id": "0NO8SsF6umjI3iQJzTycVF",
+              "name": "Jex",
+              "type": "artist",
+              "uri": "spotify:artist:0NO8SsF6umjI3iQJzTycVF"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 199462,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1TCDKv958rQjjORQaEPsLE"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1TCDKv958rQjjORQaEPsLE",
+          "id": "1TCDKv958rQjjORQaEPsLE",
+          "name": "Told You So - Acoustic Version",
+          "uri": "spotify:track:1TCDKv958rQjjORQaEPsLE",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5XjuB8WjardHuZpaMy6LXP",
+            "id": "5XjuB8WjardHuZpaMy6LXP",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273460239fbb23b8b3fe661b1f2",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02460239fbb23b8b3fe661b1f2",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851460239fbb23b8b3fe661b1f2",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Gravity",
+            "release_date": "2024-10-18",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5XjuB8WjardHuZpaMy6LXP",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4j6FBtbchyfFhBrCw9eT45"
+                },
+                "href": "https://api.spotify.com/v1/artists/4j6FBtbchyfFhBrCw9eT45",
+                "id": "4j6FBtbchyfFhBrCw9eT45",
+                "name": "Sem Vox",
+                "type": "artist",
+                "uri": "spotify:artist:4j6FBtbchyfFhBrCw9eT45"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+                },
+                "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+                "id": "6EdfpkgBzauysFts2D0LSO",
+                "name": "Jaimes",
+                "type": "artist",
+                "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5XjuB8WjardHuZpaMy6LXP"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4j6FBtbchyfFhBrCw9eT45"
+              },
+              "href": "https://api.spotify.com/v1/artists/4j6FBtbchyfFhBrCw9eT45",
+              "id": "4j6FBtbchyfFhBrCw9eT45",
+              "name": "Sem Vox",
+              "type": "artist",
+              "uri": "spotify:artist:4j6FBtbchyfFhBrCw9eT45"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+              },
+              "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+              "id": "6EdfpkgBzauysFts2D0LSO",
+              "name": "Jaimes",
+              "type": "artist",
+              "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 285472,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1vMMwDCd1Hnb91a3x9MdfX"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1vMMwDCd1Hnb91a3x9MdfX",
+          "id": "1vMMwDCd1Hnb91a3x9MdfX",
+          "name": "Gravity",
+          "uri": "spotify:track:1vMMwDCd1Hnb91a3x9MdfX",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5lyrSSLJZklByMwj2Cugjh",
+            "id": "5lyrSSLJZklByMwj2Cugjh",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273714570799bccf83120f74d77",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02714570799bccf83120f74d77",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851714570799bccf83120f74d77",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Gravity (Tomas Grey & Off Clouds Remix)",
+            "release_date": "2025-04-25",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5lyrSSLJZklByMwj2Cugjh",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0LyfQWJT6nXafLPZqxe9Of"
+                },
+                "href": "https://api.spotify.com/v1/artists/0LyfQWJT6nXafLPZqxe9Of",
+                "id": "0LyfQWJT6nXafLPZqxe9Of",
+                "name": "Various Artists",
+                "type": "artist",
+                "uri": "spotify:artist:0LyfQWJT6nXafLPZqxe9Of"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5lyrSSLJZklByMwj2Cugjh"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4j6FBtbchyfFhBrCw9eT45"
+              },
+              "href": "https://api.spotify.com/v1/artists/4j6FBtbchyfFhBrCw9eT45",
+              "id": "4j6FBtbchyfFhBrCw9eT45",
+              "name": "Sem Vox",
+              "type": "artist",
+              "uri": "spotify:artist:4j6FBtbchyfFhBrCw9eT45"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+              },
+              "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+              "id": "6EdfpkgBzauysFts2D0LSO",
+              "name": "Jaimes",
+              "type": "artist",
+              "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/324KqmU4J1mdKnHdFUE3pS"
+              },
+              "href": "https://api.spotify.com/v1/artists/324KqmU4J1mdKnHdFUE3pS",
+              "id": "324KqmU4J1mdKnHdFUE3pS",
+              "name": "Tomas Grey",
+              "type": "artist",
+              "uri": "spotify:artist:324KqmU4J1mdKnHdFUE3pS"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2Qdgd1AWVVqBmv9aTWPUfm"
+              },
+              "href": "https://api.spotify.com/v1/artists/2Qdgd1AWVVqBmv9aTWPUfm",
+              "id": "2Qdgd1AWVVqBmv9aTWPUfm",
+              "name": "Off Clouds",
+              "type": "artist",
+              "uri": "spotify:artist:2Qdgd1AWVVqBmv9aTWPUfm"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 274687,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/39iiTpCiDIx9VR3zozwuBk"
+          },
+          "href": "https://api.spotify.com/v1/tracks/39iiTpCiDIx9VR3zozwuBk",
+          "id": "39iiTpCiDIx9VR3zozwuBk",
+          "name": "Gravity - Tomas Grey & Off Clouds Remix",
+          "uri": "spotify:track:39iiTpCiDIx9VR3zozwuBk",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5MwREpSNM3JMxAq8xqe3im",
+            "id": "5MwREpSNM3JMxAq8xqe3im",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273cfe5c90a2759e12e53062c00",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02cfe5c90a2759e12e53062c00",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851cfe5c90a2759e12e53062c00",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Smile (feat. Carolina Liar)",
+            "release_date": "2024-07-19",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5MwREpSNM3JMxAq8xqe3im",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0OuSnRyi1OkLPkR4AqzJwi"
+                },
+                "href": "https://api.spotify.com/v1/artists/0OuSnRyi1OkLPkR4AqzJwi",
+                "id": "0OuSnRyi1OkLPkR4AqzJwi",
+                "name": "Carolina Liar",
+                "type": "artist",
+                "uri": "spotify:artist:0OuSnRyi1OkLPkR4AqzJwi"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5MwREpSNM3JMxAq8xqe3im"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0OuSnRyi1OkLPkR4AqzJwi"
+              },
+              "href": "https://api.spotify.com/v1/artists/0OuSnRyi1OkLPkR4AqzJwi",
+              "id": "0OuSnRyi1OkLPkR4AqzJwi",
+              "name": "Carolina Liar",
+              "type": "artist",
+              "uri": "spotify:artist:0OuSnRyi1OkLPkR4AqzJwi"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 192963,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/73SGUxXPloaU5CfeKkJf5D"
+          },
+          "href": "https://api.spotify.com/v1/tracks/73SGUxXPloaU5CfeKkJf5D",
+          "id": "73SGUxXPloaU5CfeKkJf5D",
+          "name": "Smile (feat. Carolina Liar)",
+          "uri": "spotify:track:73SGUxXPloaU5CfeKkJf5D",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7hjd1WmWPqTyrPGDaywQjK",
+            "id": "7hjd1WmWPqTyrPGDaywQjK",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273649b643439d284ecaa599d12",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02649b643439d284ecaa599d12",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851649b643439d284ecaa599d12",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Wherever You Are",
+            "release_date": "2024-06-07",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7hjd1WmWPqTyrPGDaywQjK",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+                },
+                "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+                "id": "3XINWZaloea97SIRiyTJxX",
+                "name": "DubVision",
+                "type": "artist",
+                "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+                },
+                "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+                "id": "4ukUyiEoZi8QxibfjuUsEw",
+                "name": "Shaun Farrugia",
+                "type": "artist",
+                "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7hjd1WmWPqTyrPGDaywQjK"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+              },
+              "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+              "id": "4ukUyiEoZi8QxibfjuUsEw",
+              "name": "Shaun Farrugia",
+              "type": "artist",
+              "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 207992,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4s5kizLw0McJRd4rBG06B4"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4s5kizLw0McJRd4rBG06B4",
+          "id": "4s5kizLw0McJRd4rBG06B4",
+          "name": "Wherever You Are",
+          "uri": "spotify:track:4s5kizLw0McJRd4rBG06B4",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5UPw5Z0vsHExBhH56uS3iQ",
+            "id": "5UPw5Z0vsHExBhH56uS3iQ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e13143c78e21f68a1ac624a",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e13143c78e21f68a1ac624a",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e13143c78e21f68a1ac624a",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Empty",
+            "release_date": "2024-03-08",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5UPw5Z0vsHExBhH56uS3iQ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+                },
+                "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+                "id": "3XINWZaloea97SIRiyTJxX",
+                "name": "DubVision",
+                "type": "artist",
+                "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+                },
+                "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+                "id": "6EdfpkgBzauysFts2D0LSO",
+                "name": "Jaimes",
+                "type": "artist",
+                "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5UPw5Z0vsHExBhH56uS3iQ"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+              },
+              "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+              "id": "6EdfpkgBzauysFts2D0LSO",
+              "name": "Jaimes",
+              "type": "artist",
+              "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 198425,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/575ViHchpSUjfTLCQPdE49"
+          },
+          "href": "https://api.spotify.com/v1/tracks/575ViHchpSUjfTLCQPdE49",
+          "id": "575ViHchpSUjfTLCQPdE49",
+          "name": "Empty",
+          "uri": "spotify:track:575ViHchpSUjfTLCQPdE49",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1oNttAQgPEuS0NfPsdWhaS",
+            "id": "1oNttAQgPEuS0NfPsdWhaS",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27349d401f3b7f3ee8aa234a251",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0249d401f3b7f3ee8aa234a251",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485149d401f3b7f3ee8aa234a251",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Biochemical",
+            "release_date": "2024-03-01",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1oNttAQgPEuS0NfPsdWhaS",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5nFt7a5Du2MkdAr1KniXh7"
+                },
+                "href": "https://api.spotify.com/v1/artists/5nFt7a5Du2MkdAr1KniXh7",
+                "id": "5nFt7a5Du2MkdAr1KniXh7",
+                "name": "Seth Hills",
+                "type": "artist",
+                "uri": "spotify:artist:5nFt7a5Du2MkdAr1KniXh7"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1oNttAQgPEuS0NfPsdWhaS"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5nFt7a5Du2MkdAr1KniXh7"
+              },
+              "href": "https://api.spotify.com/v1/artists/5nFt7a5Du2MkdAr1KniXh7",
+              "id": "5nFt7a5Du2MkdAr1KniXh7",
+              "name": "Seth Hills",
+              "type": "artist",
+              "uri": "spotify:artist:5nFt7a5Du2MkdAr1KniXh7"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 163809,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7nlK1F6iJ3Aih70YkltfJS"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7nlK1F6iJ3Aih70YkltfJS",
+          "id": "7nlK1F6iJ3Aih70YkltfJS",
+          "name": "Biochemical",
+          "uri": "spotify:track:7nlK1F6iJ3Aih70YkltfJS",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3Qf1lsCco4UBhUZF0ydjmx",
+            "id": "3Qf1lsCco4UBhUZF0ydjmx",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739ae4e3be97b5a4819f5882e8",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029ae4e3be97b5a4819f5882e8",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519ae4e3be97b5a4819f5882e8",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Breakaway",
+            "release_date": "2024-02-23",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3Qf1lsCco4UBhUZF0ydjmx",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+                },
+                "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+                "id": "0RViEWnZO2VhmY4oI0PhF9",
+                "name": "Mesto",
+                "type": "artist",
+                "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7g4gQKWTNj0X8BqpKpZFC0"
+                },
+                "href": "https://api.spotify.com/v1/artists/7g4gQKWTNj0X8BqpKpZFC0",
+                "id": "7g4gQKWTNj0X8BqpKpZFC0",
+                "name": "WILHELM",
+                "type": "artist",
+                "uri": "spotify:artist:7g4gQKWTNj0X8BqpKpZFC0"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3Qf1lsCco4UBhUZF0ydjmx"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+              },
+              "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+              "id": "0RViEWnZO2VhmY4oI0PhF9",
+              "name": "Mesto",
+              "type": "artist",
+              "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7g4gQKWTNj0X8BqpKpZFC0"
+              },
+              "href": "https://api.spotify.com/v1/artists/7g4gQKWTNj0X8BqpKpZFC0",
+              "id": "7g4gQKWTNj0X8BqpKpZFC0",
+              "name": "WILHELM",
+              "type": "artist",
+              "uri": "spotify:artist:7g4gQKWTNj0X8BqpKpZFC0"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 165000,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3g0eHwVjGYZaHooqGtKefQ"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3g0eHwVjGYZaHooqGtKefQ",
+          "id": "3g0eHwVjGYZaHooqGtKefQ",
+          "name": "Breakaway",
+          "uri": "spotify:track:3g0eHwVjGYZaHooqGtKefQ",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1EHfXHtB9Ynnia0yZhV6HO",
+            "id": "1EHfXHtB9Ynnia0yZhV6HO",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2732cd834c826d484dcb3414699",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e022cd834c826d484dcb3414699",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048512cd834c826d484dcb3414699",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Carry You",
+            "release_date": "2024-02-16",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1EHfXHtB9Ynnia0yZhV6HO",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2J80qXI4NHKpq5RT3xUF7V"
+                },
+                "href": "https://api.spotify.com/v1/artists/2J80qXI4NHKpq5RT3xUF7V",
+                "id": "2J80qXI4NHKpq5RT3xUF7V",
+                "name": "Third Party",
+                "type": "artist",
+                "uri": "spotify:artist:2J80qXI4NHKpq5RT3xUF7V"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1X2sRzO3K7Uvry9JWbG2iO"
+                },
+                "href": "https://api.spotify.com/v1/artists/1X2sRzO3K7Uvry9JWbG2iO",
+                "id": "1X2sRzO3K7Uvry9JWbG2iO",
+                "name": "Oaks",
+                "type": "artist",
+                "uri": "spotify:artist:1X2sRzO3K7Uvry9JWbG2iO"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1EHfXHtB9Ynnia0yZhV6HO"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2J80qXI4NHKpq5RT3xUF7V"
+              },
+              "href": "https://api.spotify.com/v1/artists/2J80qXI4NHKpq5RT3xUF7V",
+              "id": "2J80qXI4NHKpq5RT3xUF7V",
+              "name": "Third Party",
+              "type": "artist",
+              "uri": "spotify:artist:2J80qXI4NHKpq5RT3xUF7V"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1X2sRzO3K7Uvry9JWbG2iO"
+              },
+              "href": "https://api.spotify.com/v1/artists/1X2sRzO3K7Uvry9JWbG2iO",
+              "id": "1X2sRzO3K7Uvry9JWbG2iO",
+              "name": "Oaks",
+              "type": "artist",
+              "uri": "spotify:artist:1X2sRzO3K7Uvry9JWbG2iO"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6bh228LGC3eAzbplPWV02r"
+              },
+              "href": "https://api.spotify.com/v1/artists/6bh228LGC3eAzbplPWV02r",
+              "id": "6bh228LGC3eAzbplPWV02r",
+              "name": "Declan J Donovan",
+              "type": "artist",
+              "uri": "spotify:artist:6bh228LGC3eAzbplPWV02r"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 215905,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/31ZO9XuKt48Qb2eUTBynd2"
+          },
+          "href": "https://api.spotify.com/v1/tracks/31ZO9XuKt48Qb2eUTBynd2",
+          "id": "31ZO9XuKt48Qb2eUTBynd2",
+          "name": "Carry You",
+          "uri": "spotify:track:31ZO9XuKt48Qb2eUTBynd2",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/77mVDnHiUlQkGrL612rzCY",
+            "id": "77mVDnHiUlQkGrL612rzCY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273faa3bfb2cf1679e17934f484",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02faa3bfb2cf1679e17934f484",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851faa3bfb2cf1679e17934f484",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Real Love (33 Below Remix)",
+            "release_date": "2023-11-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:77mVDnHiUlQkGrL612rzCY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+                },
+                "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+                "id": "3CrKgAMSBXsnTugbUqpu6g",
+                "name": "Lloyiso",
+                "type": "artist",
+                "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4tMIsBBR8M0PsorDf0mNEz"
+                },
+                "href": "https://api.spotify.com/v1/artists/4tMIsBBR8M0PsorDf0mNEz",
+                "id": "4tMIsBBR8M0PsorDf0mNEz",
+                "name": "33 Below",
+                "type": "artist",
+                "uri": "spotify:artist:4tMIsBBR8M0PsorDf0mNEz"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/77mVDnHiUlQkGrL612rzCY"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+              },
+              "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+              "id": "3CrKgAMSBXsnTugbUqpu6g",
+              "name": "Lloyiso",
+              "type": "artist",
+              "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4tMIsBBR8M0PsorDf0mNEz"
+              },
+              "href": "https://api.spotify.com/v1/artists/4tMIsBBR8M0PsorDf0mNEz",
+              "id": "4tMIsBBR8M0PsorDf0mNEz",
+              "name": "33 Below",
+              "type": "artist",
+              "uri": "spotify:artist:4tMIsBBR8M0PsorDf0mNEz"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 178905,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1kmWZGrZwy8yOalxNJ0DUs"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1kmWZGrZwy8yOalxNJ0DUs",
+          "id": "1kmWZGrZwy8yOalxNJ0DUs",
+          "name": "Real Love - 33 Below Remix",
+          "uri": "spotify:track:1kmWZGrZwy8yOalxNJ0DUs",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5UPw5Z0vsHExBhH56uS3iQ",
+            "id": "5UPw5Z0vsHExBhH56uS3iQ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e13143c78e21f68a1ac624a",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e13143c78e21f68a1ac624a",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e13143c78e21f68a1ac624a",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Empty",
+            "release_date": "2024-03-08",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5UPw5Z0vsHExBhH56uS3iQ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+                },
+                "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+                "id": "3XINWZaloea97SIRiyTJxX",
+                "name": "DubVision",
+                "type": "artist",
+                "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+                },
+                "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+                "id": "6EdfpkgBzauysFts2D0LSO",
+                "name": "Jaimes",
+                "type": "artist",
+                "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5UPw5Z0vsHExBhH56uS3iQ"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6EdfpkgBzauysFts2D0LSO"
+              },
+              "href": "https://api.spotify.com/v1/artists/6EdfpkgBzauysFts2D0LSO",
+              "id": "6EdfpkgBzauysFts2D0LSO",
+              "name": "Jaimes",
+              "type": "artist",
+              "uri": "spotify:artist:6EdfpkgBzauysFts2D0LSO"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 198425,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0LV5p1Ry6fTDBKx2AcFn4Y"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0LV5p1Ry6fTDBKx2AcFn4Y",
+          "id": "0LV5p1Ry6fTDBKx2AcFn4Y",
+          "name": "Empty - Instrumental Mix",
+          "uri": "spotify:track:0LV5p1Ry6fTDBKx2AcFn4Y",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3joNpvmZheGoKgbIiQL1kd",
+            "id": "3joNpvmZheGoKgbIiQL1kd",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273a1fa3b113ee8cfa488d9485d",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02a1fa3b113ee8cfa488d9485d",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851a1fa3b113ee8cfa488d9485d",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Real Love (Liva K Remix)",
+            "release_date": "2023-10-20",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3joNpvmZheGoKgbIiQL1kd",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+                },
+                "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+                "id": "3CrKgAMSBXsnTugbUqpu6g",
+                "name": "Lloyiso",
+                "type": "artist",
+                "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/63mVEANeXk1p622Ejj9rBj"
+                },
+                "href": "https://api.spotify.com/v1/artists/63mVEANeXk1p622Ejj9rBj",
+                "id": "63mVEANeXk1p622Ejj9rBj",
+                "name": "Liva K",
+                "type": "artist",
+                "uri": "spotify:artist:63mVEANeXk1p622Ejj9rBj"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3joNpvmZheGoKgbIiQL1kd"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+              },
+              "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+              "id": "3CrKgAMSBXsnTugbUqpu6g",
+              "name": "Lloyiso",
+              "type": "artist",
+              "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/63mVEANeXk1p622Ejj9rBj"
+              },
+              "href": "https://api.spotify.com/v1/artists/63mVEANeXk1p622Ejj9rBj",
+              "id": "63mVEANeXk1p622Ejj9rBj",
+              "name": "Liva K",
+              "type": "artist",
+              "uri": "spotify:artist:63mVEANeXk1p622Ejj9rBj"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 177577,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3TyPUGvK4G8pdrM3oEWlwg"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3TyPUGvK4G8pdrM3oEWlwg",
+          "id": "3TyPUGvK4G8pdrM3oEWlwg",
+          "name": "Real Love - Liva K Remix",
+          "uri": "spotify:track:3TyPUGvK4G8pdrM3oEWlwg",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3Qf1lsCco4UBhUZF0ydjmx",
+            "id": "3Qf1lsCco4UBhUZF0ydjmx",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739ae4e3be97b5a4819f5882e8",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029ae4e3be97b5a4819f5882e8",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519ae4e3be97b5a4819f5882e8",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Breakaway",
+            "release_date": "2024-02-23",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3Qf1lsCco4UBhUZF0ydjmx",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+                },
+                "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+                "id": "0RViEWnZO2VhmY4oI0PhF9",
+                "name": "Mesto",
+                "type": "artist",
+                "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7g4gQKWTNj0X8BqpKpZFC0"
+                },
+                "href": "https://api.spotify.com/v1/artists/7g4gQKWTNj0X8BqpKpZFC0",
+                "id": "7g4gQKWTNj0X8BqpKpZFC0",
+                "name": "WILHELM",
+                "type": "artist",
+                "uri": "spotify:artist:7g4gQKWTNj0X8BqpKpZFC0"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3Qf1lsCco4UBhUZF0ydjmx"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+              },
+              "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+              "id": "0RViEWnZO2VhmY4oI0PhF9",
+              "name": "Mesto",
+              "type": "artist",
+              "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7g4gQKWTNj0X8BqpKpZFC0"
+              },
+              "href": "https://api.spotify.com/v1/artists/7g4gQKWTNj0X8BqpKpZFC0",
+              "id": "7g4gQKWTNj0X8BqpKpZFC0",
+              "name": "WILHELM",
+              "type": "artist",
+              "uri": "spotify:artist:7g4gQKWTNj0X8BqpKpZFC0"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 166875,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3NkSWP8Z2OfQaM2Ja5AYwC"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3NkSWP8Z2OfQaM2Ja5AYwC",
+          "id": "3NkSWP8Z2OfQaM2Ja5AYwC",
+          "name": "Breakaway - Instrumental Mix",
+          "uri": "spotify:track:3NkSWP8Z2OfQaM2Ja5AYwC",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3rmNlvswDE9CQIl3pElKXP",
+            "id": "3rmNlvswDE9CQIl3pElKXP",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273ddf2184f1547bdfa5b294568",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ddf2184f1547bdfa5b294568",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851ddf2184f1547bdfa5b294568",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Real Love (Liva K Remix)",
+            "release_date": "2023-10-20",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3rmNlvswDE9CQIl3pElKXP",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+                },
+                "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+                "id": "3CrKgAMSBXsnTugbUqpu6g",
+                "name": "Lloyiso",
+                "type": "artist",
+                "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/63mVEANeXk1p622Ejj9rBj"
+                },
+                "href": "https://api.spotify.com/v1/artists/63mVEANeXk1p622Ejj9rBj",
+                "id": "63mVEANeXk1p622Ejj9rBj",
+                "name": "Liva K",
+                "type": "artist",
+                "uri": "spotify:artist:63mVEANeXk1p622Ejj9rBj"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3rmNlvswDE9CQIl3pElKXP"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+              },
+              "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+              "id": "3CrKgAMSBXsnTugbUqpu6g",
+              "name": "Lloyiso",
+              "type": "artist",
+              "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/63mVEANeXk1p622Ejj9rBj"
+              },
+              "href": "https://api.spotify.com/v1/artists/63mVEANeXk1p622Ejj9rBj",
+              "id": "63mVEANeXk1p622Ejj9rBj",
+              "name": "Liva K",
+              "type": "artist",
+              "uri": "spotify:artist:63mVEANeXk1p622Ejj9rBj"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 393254,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/46WJNcRBzvg7r1MnfOGnUw"
+          },
+          "href": "https://api.spotify.com/v1/tracks/46WJNcRBzvg7r1MnfOGnUw",
+          "id": "46WJNcRBzvg7r1MnfOGnUw",
+          "name": "Real Love - Liva K Extended Remix",
+          "uri": "spotify:track:46WJNcRBzvg7r1MnfOGnUw",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1EHfXHtB9Ynnia0yZhV6HO",
+            "id": "1EHfXHtB9Ynnia0yZhV6HO",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2732cd834c826d484dcb3414699",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e022cd834c826d484dcb3414699",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048512cd834c826d484dcb3414699",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Carry You",
+            "release_date": "2024-02-16",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1EHfXHtB9Ynnia0yZhV6HO",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2J80qXI4NHKpq5RT3xUF7V"
+                },
+                "href": "https://api.spotify.com/v1/artists/2J80qXI4NHKpq5RT3xUF7V",
+                "id": "2J80qXI4NHKpq5RT3xUF7V",
+                "name": "Third Party",
+                "type": "artist",
+                "uri": "spotify:artist:2J80qXI4NHKpq5RT3xUF7V"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1X2sRzO3K7Uvry9JWbG2iO"
+                },
+                "href": "https://api.spotify.com/v1/artists/1X2sRzO3K7Uvry9JWbG2iO",
+                "id": "1X2sRzO3K7Uvry9JWbG2iO",
+                "name": "Oaks",
+                "type": "artist",
+                "uri": "spotify:artist:1X2sRzO3K7Uvry9JWbG2iO"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1EHfXHtB9Ynnia0yZhV6HO"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2J80qXI4NHKpq5RT3xUF7V"
+              },
+              "href": "https://api.spotify.com/v1/artists/2J80qXI4NHKpq5RT3xUF7V",
+              "id": "2J80qXI4NHKpq5RT3xUF7V",
+              "name": "Third Party",
+              "type": "artist",
+              "uri": "spotify:artist:2J80qXI4NHKpq5RT3xUF7V"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1X2sRzO3K7Uvry9JWbG2iO"
+              },
+              "href": "https://api.spotify.com/v1/artists/1X2sRzO3K7Uvry9JWbG2iO",
+              "id": "1X2sRzO3K7Uvry9JWbG2iO",
+              "name": "Oaks",
+              "type": "artist",
+              "uri": "spotify:artist:1X2sRzO3K7Uvry9JWbG2iO"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6bh228LGC3eAzbplPWV02r"
+              },
+              "href": "https://api.spotify.com/v1/artists/6bh228LGC3eAzbplPWV02r",
+              "id": "6bh228LGC3eAzbplPWV02r",
+              "name": "Declan J Donovan",
+              "type": "artist",
+              "uri": "spotify:artist:6bh228LGC3eAzbplPWV02r"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 215905,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0zNmgY5E8fFFflu4TzoTcQ"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0zNmgY5E8fFFflu4TzoTcQ",
+          "id": "0zNmgY5E8fFFflu4TzoTcQ",
+          "name": "Carry You - Instrumental Mix",
+          "uri": "spotify:track:0zNmgY5E8fFFflu4TzoTcQ",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7jENFxE6ngcSKd9UqjEKxY",
+            "id": "7jENFxE6ngcSKd9UqjEKxY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273ee035d3ad88f5ef632a6464a",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ee035d3ad88f5ef632a6464a",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851ee035d3ad88f5ef632a6464a",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Real Love",
+            "release_date": "2023-09-22",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7jENFxE6ngcSKd9UqjEKxY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+                },
+                "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+                "id": "3CrKgAMSBXsnTugbUqpu6g",
+                "name": "Lloyiso",
+                "type": "artist",
+                "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7jENFxE6ngcSKd9UqjEKxY"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3CrKgAMSBXsnTugbUqpu6g"
+              },
+              "href": "https://api.spotify.com/v1/artists/3CrKgAMSBXsnTugbUqpu6g",
+              "id": "3CrKgAMSBXsnTugbUqpu6g",
+              "name": "Lloyiso",
+              "type": "artist",
+              "uri": "spotify:artist:3CrKgAMSBXsnTugbUqpu6g"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 163000,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6afdNrotJ1PCt9DoFiHpLj"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6afdNrotJ1PCt9DoFiHpLj",
+          "id": "6afdNrotJ1PCt9DoFiHpLj",
+          "name": "Real Love",
+          "uri": "spotify:track:6afdNrotJ1PCt9DoFiHpLj",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/4cgBeHPgTibGZe8JW4c0lD",
+            "id": "4cgBeHPgTibGZe8JW4c0lD",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2737993573de9a95edee577f04d",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e027993573de9a95edee577f04d",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048517993573de9a95edee577f04d",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Hurricane",
+            "release_date": "2023-06-02",
+            "release_date_precision": "day",
+            "uri": "spotify:album:4cgBeHPgTibGZe8JW4c0lD",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2GPNLOJ6KU8G9VyrLsz1Sw"
+                },
+                "href": "https://api.spotify.com/v1/artists/2GPNLOJ6KU8G9VyrLsz1Sw",
+                "id": "2GPNLOJ6KU8G9VyrLsz1Sw",
+                "name": "Sentinel",
+                "type": "artist",
+                "uri": "spotify:artist:2GPNLOJ6KU8G9VyrLsz1Sw"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+                },
+                "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+                "id": "7Io0XduXk7aOHFHA7sLru2",
+                "name": "Bonn",
+                "type": "artist",
+                "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/4cgBeHPgTibGZe8JW4c0lD"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2GPNLOJ6KU8G9VyrLsz1Sw"
+              },
+              "href": "https://api.spotify.com/v1/artists/2GPNLOJ6KU8G9VyrLsz1Sw",
+              "id": "2GPNLOJ6KU8G9VyrLsz1Sw",
+              "name": "Sentinel",
+              "type": "artist",
+              "uri": "spotify:artist:2GPNLOJ6KU8G9VyrLsz1Sw"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 198867,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5RfVafaeEEiqC0Z3LsBaZw"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5RfVafaeEEiqC0Z3LsBaZw",
+          "id": "5RfVafaeEEiqC0Z3LsBaZw",
+          "name": "Hurricane",
+          "uri": "spotify:track:5RfVafaeEEiqC0Z3LsBaZw",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7ITpVarEWNNzTf2pNHBrcl",
+            "id": "7ITpVarEWNNzTf2pNHBrcl",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27304fecdca8320491e2713d149",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0204fecdca8320491e2713d149",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485104fecdca8320491e2713d149",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Cocoon (Martin Garrix & Space Ducks Remix)",
+            "release_date": "2023-02-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7ITpVarEWNNzTf2pNHBrcl",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/12Zk1DFhCbHY6v3xep2ZjI"
+                },
+                "href": "https://api.spotify.com/v1/artists/12Zk1DFhCbHY6v3xep2ZjI",
+                "id": "12Zk1DFhCbHY6v3xep2ZjI",
+                "name": "070 Shake",
+                "type": "artist",
+                "uri": "spotify:artist:12Zk1DFhCbHY6v3xep2ZjI"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0KWooIVFqa6Gt0BtpdudK6"
+                },
+                "href": "https://api.spotify.com/v1/artists/0KWooIVFqa6Gt0BtpdudK6",
+                "id": "0KWooIVFqa6Gt0BtpdudK6",
+                "name": "Space Ducks",
+                "type": "artist",
+                "uri": "spotify:artist:0KWooIVFqa6Gt0BtpdudK6"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7ITpVarEWNNzTf2pNHBrcl"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/12Zk1DFhCbHY6v3xep2ZjI"
+              },
+              "href": "https://api.spotify.com/v1/artists/12Zk1DFhCbHY6v3xep2ZjI",
+              "id": "12Zk1DFhCbHY6v3xep2ZjI",
+              "name": "070 Shake",
+              "type": "artist",
+              "uri": "spotify:artist:12Zk1DFhCbHY6v3xep2ZjI"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0KWooIVFqa6Gt0BtpdudK6"
+              },
+              "href": "https://api.spotify.com/v1/artists/0KWooIVFqa6Gt0BtpdudK6",
+              "id": "0KWooIVFqa6Gt0BtpdudK6",
+              "name": "Space Ducks",
+              "type": "artist",
+              "uri": "spotify:artist:0KWooIVFqa6Gt0BtpdudK6"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 202204,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0P7toBXcgVgAcArpns3RmH"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0P7toBXcgVgAcArpns3RmH",
+          "id": "0P7toBXcgVgAcArpns3RmH",
+          "name": "Cocoon - Martin Garrix & Space Ducks Remix",
+          "uri": "spotify:track:0P7toBXcgVgAcArpns3RmH",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1D8XFqGY27IpYFAKB61h8v",
+            "id": "1D8XFqGY27IpYFAKB61h8v",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2735934206d1f66d8856b8221dd",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e025934206d1f66d8856b8221dd",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048515934206d1f66d8856b8221dd",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Hero",
+            "release_date": "2022-12-08",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1D8XFqGY27IpYFAKB61h8v",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/164Uj4eKjl6zTBKfJLFKKK"
+                },
+                "href": "https://api.spotify.com/v1/artists/164Uj4eKjl6zTBKfJLFKKK",
+                "id": "164Uj4eKjl6zTBKfJLFKKK",
+                "name": "JVKE",
+                "type": "artist",
+                "uri": "spotify:artist:164Uj4eKjl6zTBKfJLFKKK"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1D8XFqGY27IpYFAKB61h8v"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/164Uj4eKjl6zTBKfJLFKKK"
+              },
+              "href": "https://api.spotify.com/v1/artists/164Uj4eKjl6zTBKfJLFKKK",
+              "id": "164Uj4eKjl6zTBKfJLFKKK",
+              "name": "JVKE",
+              "type": "artist",
+              "uri": "spotify:artist:164Uj4eKjl6zTBKfJLFKKK"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 160714,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4Wu62DoQg1ECGlDKDfo30R"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4Wu62DoQg1ECGlDKDfo30R",
+          "id": "4Wu62DoQg1ECGlDKDfo30R",
+          "name": "Hero",
+          "uri": "spotify:track:4Wu62DoQg1ECGlDKDfo30R",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7GFLvptwUjJfXt21DbQmQQ",
+            "id": "7GFLvptwUjJfXt21DbQmQQ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273daa30a30d8c91f799d5b999c",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02daa30a30d8c91f799d5b999c",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851daa30a30d8c91f799d5b999c",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Something",
+            "release_date": "2022-07-29",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7GFLvptwUjJfXt21DbQmQQ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/53M4Iv2RkzzxFFvW2B1jhC"
+                },
+                "href": "https://api.spotify.com/v1/artists/53M4Iv2RkzzxFFvW2B1jhC",
+                "id": "53M4Iv2RkzzxFFvW2B1jhC",
+                "name": "Breathe Carolina",
+                "type": "artist",
+                "uri": "spotify:artist:53M4Iv2RkzzxFFvW2B1jhC"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7GFLvptwUjJfXt21DbQmQQ"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/53M4Iv2RkzzxFFvW2B1jhC"
+              },
+              "href": "https://api.spotify.com/v1/artists/53M4Iv2RkzzxFFvW2B1jhC",
+              "id": "53M4Iv2RkzzxFFvW2B1jhC",
+              "name": "Breathe Carolina",
+              "type": "artist",
+              "uri": "spotify:artist:53M4Iv2RkzzxFFvW2B1jhC"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 163124,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6LHXb1sGs72iTmpSr0603b"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6LHXb1sGs72iTmpSr0603b",
+          "id": "6LHXb1sGs72iTmpSr0603b",
+          "name": "Something",
+          "uri": "spotify:track:6LHXb1sGs72iTmpSr0603b",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": true,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1KNHmfZjkA5Fq52nfOK0sW",
+            "id": "1KNHmfZjkA5Fq52nfOK0sW",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273bd114f3939212795035b0bd3",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02bd114f3939212795035b0bd3",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851bd114f3939212795035b0bd3",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Loop",
+            "release_date": "2022-07-15",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1KNHmfZjkA5Fq52nfOK0sW",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7uas0F5EhsZg6KDJ7yy7rW"
+                },
+                "href": "https://api.spotify.com/v1/artists/7uas0F5EhsZg6KDJ7yy7rW",
+                "id": "7uas0F5EhsZg6KDJ7yy7rW",
+                "name": "DallasK",
+                "type": "artist",
+                "uri": "spotify:artist:7uas0F5EhsZg6KDJ7yy7rW"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4xnihxcoXWK3UqryOSnbw5"
+                },
+                "href": "https://api.spotify.com/v1/artists/4xnihxcoXWK3UqryOSnbw5",
+                "id": "4xnihxcoXWK3UqryOSnbw5",
+                "name": "Sasha Alex Sloan",
+                "type": "artist",
+                "uri": "spotify:artist:4xnihxcoXWK3UqryOSnbw5"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1KNHmfZjkA5Fq52nfOK0sW"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7uas0F5EhsZg6KDJ7yy7rW"
+              },
+              "href": "https://api.spotify.com/v1/artists/7uas0F5EhsZg6KDJ7yy7rW",
+              "id": "7uas0F5EhsZg6KDJ7yy7rW",
+              "name": "DallasK",
+              "type": "artist",
+              "uri": "spotify:artist:7uas0F5EhsZg6KDJ7yy7rW"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4xnihxcoXWK3UqryOSnbw5"
+              },
+              "href": "https://api.spotify.com/v1/artists/4xnihxcoXWK3UqryOSnbw5",
+              "id": "4xnihxcoXWK3UqryOSnbw5",
+              "name": "Sasha Alex Sloan",
+              "type": "artist",
+              "uri": "spotify:artist:4xnihxcoXWK3UqryOSnbw5"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 190560,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0lqgo6rIBS0nVsvppZC3Ay"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0lqgo6rIBS0nVsvppZC3Ay",
+          "id": "0lqgo6rIBS0nVsvppZC3Ay",
+          "name": "Loop",
+          "uri": "spotify:track:0lqgo6rIBS0nVsvppZC3Ay",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/39oISAQPcYRNjQqKvYroME",
+            "id": "39oISAQPcYRNjQqKvYroME",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2734b50bc350f847b654dd1466b",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e024b50bc350f847b654dd1466b",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048514b50bc350f847b654dd1466b",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "If We’ll Ever Be Remembered",
+            "release_date": "2022-04-29",
+            "release_date_precision": "day",
+            "uri": "spotify:album:39oISAQPcYRNjQqKvYroME",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+                },
+                "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+                "id": "4ukUyiEoZi8QxibfjuUsEw",
+                "name": "Shaun Farrugia",
+                "type": "artist",
+                "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/39oISAQPcYRNjQqKvYroME"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+              },
+              "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+              "id": "4ukUyiEoZi8QxibfjuUsEw",
+              "name": "Shaun Farrugia",
+              "type": "artist",
+              "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 210505,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6wnzt59p7i8cAyuWl1avwr"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6wnzt59p7i8cAyuWl1avwr",
+          "id": "6wnzt59p7i8cAyuWl1avwr",
+          "name": "If We’ll Ever Be Remembered",
+          "uri": "spotify:track:6wnzt59p7i8cAyuWl1avwr",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3d0m6Irp7vA5GAR5BiwC6x",
+            "id": "3d0m6Irp7vA5GAR5BiwC6x",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733daaba47d41285334c012b29",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023daaba47d41285334c012b29",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513daaba47d41285334c012b29",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Oxygen",
+            "release_date": "2022-04-29",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3d0m6Irp7vA5GAR5BiwC6x",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+                },
+                "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+                "id": "3XINWZaloea97SIRiyTJxX",
+                "name": "DubVision",
+                "type": "artist",
+                "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0NST5cNxDtRZuToY6ngC0k"
+                },
+                "href": "https://api.spotify.com/v1/artists/0NST5cNxDtRZuToY6ngC0k",
+                "id": "0NST5cNxDtRZuToY6ngC0k",
+                "name": "Jordan Grace",
+                "type": "artist",
+                "uri": "spotify:artist:0NST5cNxDtRZuToY6ngC0k"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3d0m6Irp7vA5GAR5BiwC6x"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0NST5cNxDtRZuToY6ngC0k"
+              },
+              "href": "https://api.spotify.com/v1/artists/0NST5cNxDtRZuToY6ngC0k",
+              "id": "0NST5cNxDtRZuToY6ngC0k",
+              "name": "Jordan Grace",
+              "type": "artist",
+              "uri": "spotify:artist:0NST5cNxDtRZuToY6ngC0k"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 189921,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4pmUI17u8L2FALW17kuEec"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4pmUI17u8L2FALW17kuEec",
+          "id": "4pmUI17u8L2FALW17kuEec",
+          "name": "Oxygen",
+          "uri": "spotify:track:4pmUI17u8L2FALW17kuEec",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/29TIn4cyGh1eSZmQ1jK6N9",
+            "id": "29TIn4cyGh1eSZmQ1jK6N9",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739db7bb3090766fdd5112aece",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029db7bb3090766fdd5112aece",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519db7bb3090766fdd5112aece",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Aurora",
+            "release_date": "2022-04-26",
+            "release_date_precision": "day",
+            "uri": "spotify:album:29TIn4cyGh1eSZmQ1jK6N9",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/26JVnujQQ3lEML8t9p3X1J"
+                },
+                "href": "https://api.spotify.com/v1/artists/26JVnujQQ3lEML8t9p3X1J",
+                "id": "26JVnujQQ3lEML8t9p3X1J",
+                "name": "Blinders",
+                "type": "artist",
+                "uri": "spotify:artist:26JVnujQQ3lEML8t9p3X1J"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/29TIn4cyGh1eSZmQ1jK6N9"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/26JVnujQQ3lEML8t9p3X1J"
+              },
+              "href": "https://api.spotify.com/v1/artists/26JVnujQQ3lEML8t9p3X1J",
+              "id": "26JVnujQQ3lEML8t9p3X1J",
+              "name": "Blinders",
+              "type": "artist",
+              "uri": "spotify:artist:26JVnujQQ3lEML8t9p3X1J"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 210468,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5w0264qq5wQpYfNiPpsuqE"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5w0264qq5wQpYfNiPpsuqE",
+          "id": "5w0264qq5wQpYfNiPpsuqE",
+          "name": "Aurora",
+          "uri": "spotify:track:5w0264qq5wQpYfNiPpsuqE",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2C42ypjCBqDiGZPzGAz7sI",
+            "id": "2C42ypjCBqDiGZPzGAz7sI",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2730bf44090874be856fb3f643e",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e020bf44090874be856fb3f643e",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048510bf44090874be856fb3f643e",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Find You",
+            "release_date": "2022-04-22",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2C42ypjCBqDiGZPzGAz7sI",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7MFJyevu6jq0shwDuVLymu"
+                },
+                "href": "https://api.spotify.com/v1/artists/7MFJyevu6jq0shwDuVLymu",
+                "id": "7MFJyevu6jq0shwDuVLymu",
+                "name": "Justin Mylo",
+                "type": "artist",
+                "uri": "spotify:artist:7MFJyevu6jq0shwDuVLymu"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2C42ypjCBqDiGZPzGAz7sI"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7MFJyevu6jq0shwDuVLymu"
+              },
+              "href": "https://api.spotify.com/v1/artists/7MFJyevu6jq0shwDuVLymu",
+              "id": "7MFJyevu6jq0shwDuVLymu",
+              "name": "Justin Mylo",
+              "type": "artist",
+              "uri": "spotify:artist:7MFJyevu6jq0shwDuVLymu"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1E1W3to8HhGSkkIEUMwEjd"
+              },
+              "href": "https://api.spotify.com/v1/artists/1E1W3to8HhGSkkIEUMwEjd",
+              "id": "1E1W3to8HhGSkkIEUMwEjd",
+              "name": "Dewain Whitmore",
+              "type": "artist",
+              "uri": "spotify:artist:1E1W3to8HhGSkkIEUMwEjd"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 228750,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/20h5SXbpPifAJ7mRG9HY56"
+          },
+          "href": "https://api.spotify.com/v1/tracks/20h5SXbpPifAJ7mRG9HY56",
+          "id": "20h5SXbpPifAJ7mRG9HY56",
+          "name": "Find You",
+          "uri": "spotify:track:20h5SXbpPifAJ7mRG9HY56",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6BcLKqcXk4Da5qkojpSMUZ",
+            "id": "6BcLKqcXk4Da5qkojpSMUZ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273d0db07d003daa12840cf6fcd",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02d0db07d003daa12840cf6fcd",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851d0db07d003daa12840cf6fcd",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Funk",
+            "release_date": "2022-04-19",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6BcLKqcXk4Da5qkojpSMUZ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+                },
+                "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+                "id": "2vUCVkeZjzDcaoX4gagHdV",
+                "name": "Julian Jordan",
+                "type": "artist",
+                "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6BcLKqcXk4Da5qkojpSMUZ"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+              "id": "2vUCVkeZjzDcaoX4gagHdV",
+              "name": "Julian Jordan",
+              "type": "artist",
+              "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 189600,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1Pp2kd23lBQj3Gf9uBFSNj"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1Pp2kd23lBQj3Gf9uBFSNj",
+          "id": "1Pp2kd23lBQj3Gf9uBFSNj",
+          "name": "Funk",
+          "uri": "spotify:track:1Pp2kd23lBQj3Gf9uBFSNj",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7eIDupqYq3dYiaLPmv71bY",
+            "id": "7eIDupqYq3dYiaLPmv71bY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273966ee66d723744788a24dfcc",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02966ee66d723744788a24dfcc",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851966ee66d723744788a24dfcc",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Starlight (Keep Me Afloat)",
+            "release_date": "2022-04-15",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7eIDupqYq3dYiaLPmv71bY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+                },
+                "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+                "id": "3XINWZaloea97SIRiyTJxX",
+                "name": "DubVision",
+                "type": "artist",
+                "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+                },
+                "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+                "id": "4ukUyiEoZi8QxibfjuUsEw",
+                "name": "Shaun Farrugia",
+                "type": "artist",
+                "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7eIDupqYq3dYiaLPmv71bY"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4ukUyiEoZi8QxibfjuUsEw"
+              },
+              "href": "https://api.spotify.com/v1/artists/4ukUyiEoZi8QxibfjuUsEw",
+              "id": "4ukUyiEoZi8QxibfjuUsEw",
+              "name": "Shaun Farrugia",
+              "type": "artist",
+              "uri": "spotify:artist:4ukUyiEoZi8QxibfjuUsEw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 202670,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4UQy41kC5LjzwQuiuWOpwA"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4UQy41kC5LjzwQuiuWOpwA",
+          "id": "4UQy41kC5LjzwQuiuWOpwA",
+          "name": "Starlight (Keep Me Afloat)",
+          "uri": "spotify:track:4UQy41kC5LjzwQuiuWOpwA",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3NAnf9IjYQYxLXEPxMdnuC",
+            "id": "3NAnf9IjYQYxLXEPxMdnuC",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2738f5e61eb789aea52d4799123",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e028f5e61eb789aea52d4799123",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048518f5e61eb789aea52d4799123",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Good Morning",
+            "release_date": "2022-04-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3NAnf9IjYQYxLXEPxMdnuC",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3NAnf9IjYQYxLXEPxMdnuC"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 181428,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5vbFDDuHmTqHR8tGxiipf2"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5vbFDDuHmTqHR8tGxiipf2",
+          "id": "5vbFDDuHmTqHR8tGxiipf2",
+          "name": "Good Morning",
+          "uri": "spotify:track:5vbFDDuHmTqHR8tGxiipf2",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/35xmlcqBI4rtJZXiDAI9Xo",
+            "id": "35xmlcqBI4rtJZXiDAI9Xo",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273c45c00b377a0887fa330dc52",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02c45c00b377a0887fa330dc52",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851c45c00b377a0887fa330dc52",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Quantum",
+            "release_date": "2022-04-08",
+            "release_date_precision": "day",
+            "uri": "spotify:album:35xmlcqBI4rtJZXiDAI9Xo",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+                },
+                "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+                "id": "4mHAu7NX2UNsnGXjviBD9e",
+                "name": "Brooks",
+                "type": "artist",
+                "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/35xmlcqBI4rtJZXiDAI9Xo"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4mHAu7NX2UNsnGXjviBD9e"
+              },
+              "href": "https://api.spotify.com/v1/artists/4mHAu7NX2UNsnGXjviBD9e",
+              "id": "4mHAu7NX2UNsnGXjviBD9e",
+              "name": "Brooks",
+              "type": "artist",
+              "uri": "spotify:artist:4mHAu7NX2UNsnGXjviBD9e"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 178593,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7cmpWAZsamIlIiyU1aMGZD"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7cmpWAZsamIlIiyU1aMGZD",
+          "id": "7cmpWAZsamIlIiyU1aMGZD",
+          "name": "Quantum",
+          "uri": "spotify:track:7cmpWAZsamIlIiyU1aMGZD",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/4UALxeyoQXVRVFJdMJ05a0",
+            "id": "4UALxeyoQXVRVFJdMJ05a0",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273996c5225b9234709b8483b7f",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02996c5225b9234709b8483b7f",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851996c5225b9234709b8483b7f",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Reboot",
+            "release_date": "2022-04-05",
+            "release_date_precision": "day",
+            "uri": "spotify:album:4UALxeyoQXVRVFJdMJ05a0",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0ClkclGbzsEY0aBtqq8MrB"
+                },
+                "href": "https://api.spotify.com/v1/artists/0ClkclGbzsEY0aBtqq8MrB",
+                "id": "0ClkclGbzsEY0aBtqq8MrB",
+                "name": "Vluarr",
+                "type": "artist",
+                "uri": "spotify:artist:0ClkclGbzsEY0aBtqq8MrB"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/4UALxeyoQXVRVFJdMJ05a0"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0ClkclGbzsEY0aBtqq8MrB"
+              },
+              "href": "https://api.spotify.com/v1/artists/0ClkclGbzsEY0aBtqq8MrB",
+              "id": "0ClkclGbzsEY0aBtqq8MrB",
+              "name": "Vluarr",
+              "type": "artist",
+              "uri": "spotify:artist:0ClkclGbzsEY0aBtqq8MrB"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 163928,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1Q7OXxsTM8aUaZ3BbPfIDb"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1Q7OXxsTM8aUaZ3BbPfIDb",
+          "id": "1Q7OXxsTM8aUaZ3BbPfIDb",
+          "name": "Reboot",
+          "uri": "spotify:track:1Q7OXxsTM8aUaZ3BbPfIDb",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1MQrMWrG8qHRBuTWvNA68j",
+            "id": "1MQrMWrG8qHRBuTWvNA68j",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2737fa03ac64c74b4c66a518a0e",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e027fa03ac64c74b4c66a518a0e",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048517fa03ac64c74b4c66a518a0e",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Limitless",
+            "release_date": "2022-04-01",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1MQrMWrG8qHRBuTWvNA68j",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+                },
+                "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+                "id": "0RViEWnZO2VhmY4oI0PhF9",
+                "name": "Mesto",
+                "type": "artist",
+                "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1MQrMWrG8qHRBuTWvNA68j"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0RViEWnZO2VhmY4oI0PhF9"
+              },
+              "href": "https://api.spotify.com/v1/artists/0RViEWnZO2VhmY4oI0PhF9",
+              "id": "0RViEWnZO2VhmY4oI0PhF9",
+              "name": "Mesto",
+              "type": "artist",
+              "uri": "spotify:artist:0RViEWnZO2VhmY4oI0PhF9"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 146681,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7MA8T4pKN6VeBIEGE9hggN"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7MA8T4pKN6VeBIEGE9hggN",
+          "id": "7MA8T4pKN6VeBIEGE9hggN",
+          "name": "Limitless",
+          "uri": "spotify:track:7MA8T4pKN6VeBIEGE9hggN",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0mHq8oTwln3MA72n3uHscJ",
+            "id": "0mHq8oTwln3MA72n3uHscJ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27317358352e5cdfa08af5f2a08",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0217358352e5cdfa08af5f2a08",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485117358352e5cdfa08af5f2a08",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Follow",
+            "release_date": "2022-03-25",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0mHq8oTwln3MA72n3uHscJ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2qxJFvFYMEDqd7ui6kSAcq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2qxJFvFYMEDqd7ui6kSAcq",
+                "id": "2qxJFvFYMEDqd7ui6kSAcq",
+                "name": "Zedd",
+                "type": "artist",
+                "uri": "spotify:artist:2qxJFvFYMEDqd7ui6kSAcq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0mHq8oTwln3MA72n3uHscJ"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2qxJFvFYMEDqd7ui6kSAcq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2qxJFvFYMEDqd7ui6kSAcq",
+              "id": "2qxJFvFYMEDqd7ui6kSAcq",
+              "name": "Zedd",
+              "type": "artist",
+              "uri": "spotify:artist:2qxJFvFYMEDqd7ui6kSAcq"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 221220,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5aXTfpNOqLj35ydEiLio67"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5aXTfpNOqLj35ydEiLio67",
+          "id": "5aXTfpNOqLj35ydEiLio67",
+          "name": "Follow",
+          "uri": "spotify:track:5aXTfpNOqLj35ydEiLio67",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2x42tFpwgEL9jLhhtmo8ib",
+            "id": "2x42tFpwgEL9jLhhtmo8ib",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e1db89c9fcc16eadb221ae4",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e1db89c9fcc16eadb221ae4",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e1db89c9fcc16eadb221ae4",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Won't Let You Go (Remix Contest Winners)",
+            "release_date": "2022-03-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2x42tFpwgEL9jLhhtmo8ib",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2x42tFpwgEL9jLhhtmo8ib"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0MMdZHo4Jeldyg5awD2w5V"
+              },
+              "href": "https://api.spotify.com/v1/artists/0MMdZHo4Jeldyg5awD2w5V",
+              "id": "0MMdZHo4Jeldyg5awD2w5V",
+              "name": "Eleganto",
+              "type": "artist",
+              "uri": "spotify:artist:0MMdZHo4Jeldyg5awD2w5V"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 200000,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4Fo8clhqsgpGxhtSFnJfeX"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4Fo8clhqsgpGxhtSFnJfeX",
+          "id": "4Fo8clhqsgpGxhtSFnJfeX",
+          "name": "Won't Let You Go - Eleganto Remix",
+          "uri": "spotify:track:4Fo8clhqsgpGxhtSFnJfeX",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2x42tFpwgEL9jLhhtmo8ib",
+            "id": "2x42tFpwgEL9jLhhtmo8ib",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e1db89c9fcc16eadb221ae4",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e1db89c9fcc16eadb221ae4",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e1db89c9fcc16eadb221ae4",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Won't Let You Go (Remix Contest Winners)",
+            "release_date": "2022-03-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2x42tFpwgEL9jLhhtmo8ib",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2x42tFpwgEL9jLhhtmo8ib"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5oxLZ8XdAuQefQ0k99U1fO"
+              },
+              "href": "https://api.spotify.com/v1/artists/5oxLZ8XdAuQefQ0k99U1fO",
+              "id": "5oxLZ8XdAuQefQ0k99U1fO",
+              "name": "Exbow",
+              "type": "artist",
+              "uri": "spotify:artist:5oxLZ8XdAuQefQ0k99U1fO"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 226190,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2pjnmmEcs0t3oU2sErCL66"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2pjnmmEcs0t3oU2sErCL66",
+          "id": "2pjnmmEcs0t3oU2sErCL66",
+          "name": "Won't Let You Go - Exbow Remix",
+          "uri": "spotify:track:2pjnmmEcs0t3oU2sErCL66",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2x42tFpwgEL9jLhhtmo8ib",
+            "id": "2x42tFpwgEL9jLhhtmo8ib",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e1db89c9fcc16eadb221ae4",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e1db89c9fcc16eadb221ae4",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e1db89c9fcc16eadb221ae4",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Won't Let You Go (Remix Contest Winners)",
+            "release_date": "2022-03-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2x42tFpwgEL9jLhhtmo8ib",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2x42tFpwgEL9jLhhtmo8ib"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0y0mNvcQKUUsbRlOcekXG4"
+              },
+              "href": "https://api.spotify.com/v1/artists/0y0mNvcQKUUsbRlOcekXG4",
+              "id": "0y0mNvcQKUUsbRlOcekXG4",
+              "name": "MAZAN",
+              "type": "artist",
+              "uri": "spotify:artist:0y0mNvcQKUUsbRlOcekXG4"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 202258,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4oOPfzPJsTXySl8mud4QPx"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4oOPfzPJsTXySl8mud4QPx",
+          "id": "4oOPfzPJsTXySl8mud4QPx",
+          "name": "Won't Let You Go - MAZAN Remix",
+          "uri": "spotify:track:4oOPfzPJsTXySl8mud4QPx",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2x42tFpwgEL9jLhhtmo8ib",
+            "id": "2x42tFpwgEL9jLhhtmo8ib",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e1db89c9fcc16eadb221ae4",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e1db89c9fcc16eadb221ae4",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e1db89c9fcc16eadb221ae4",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Won't Let You Go (Remix Contest Winners)",
+            "release_date": "2022-03-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2x42tFpwgEL9jLhhtmo8ib",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2x42tFpwgEL9jLhhtmo8ib"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0oRQurSfsPiBqnEZMZ1G05"
+              },
+              "href": "https://api.spotify.com/v1/artists/0oRQurSfsPiBqnEZMZ1G05",
+              "id": "0oRQurSfsPiBqnEZMZ1G05",
+              "name": "Gabriel Kirsh",
+              "type": "artist",
+              "uri": "spotify:artist:0oRQurSfsPiBqnEZMZ1G05"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 4,
+          "duration_ms": 237142,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2AxJmp5HeYKMleHJ7XuhpY"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2AxJmp5HeYKMleHJ7XuhpY",
+          "id": "2AxJmp5HeYKMleHJ7XuhpY",
+          "name": "Won't Let You Go - Gabriel Kirsh Remix",
+          "uri": "spotify:track:2AxJmp5HeYKMleHJ7XuhpY",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2x42tFpwgEL9jLhhtmo8ib",
+            "id": "2x42tFpwgEL9jLhhtmo8ib",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2733e1db89c9fcc16eadb221ae4",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e023e1db89c9fcc16eadb221ae4",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048513e1db89c9fcc16eadb221ae4",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Won't Let You Go (Remix Contest Winners)",
+            "release_date": "2022-03-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2x42tFpwgEL9jLhhtmo8ib",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2x42tFpwgEL9jLhhtmo8ib"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5wtxbzgYhdnCUNb3z4ulUA"
+              },
+              "href": "https://api.spotify.com/v1/artists/5wtxbzgYhdnCUNb3z4ulUA",
+              "id": "5wtxbzgYhdnCUNb3z4ulUA",
+              "name": "Jack & James",
+              "type": "artist",
+              "uri": "spotify:artist:5wtxbzgYhdnCUNb3z4ulUA"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 5,
+          "duration_ms": 192283,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6HyhX7xdiT5AEILORPL9pO"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6HyhX7xdiT5AEILORPL9pO",
+          "id": "6HyhX7xdiT5AEILORPL9pO",
+          "name": "Won't Let You Go - Jack & James Remix",
+          "uri": "spotify:track:6HyhX7xdiT5AEILORPL9pO",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/4QxfiUo90NEmUnyNHE1x8h",
+            "id": "4QxfiUo90NEmUnyNHE1x8h",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27380498b63e98960e2dbac41ea",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0280498b63e98960e2dbac41ea",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485180498b63e98960e2dbac41ea",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Won’t Let You Go",
+            "release_date": "2021-12-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:4QxfiUo90NEmUnyNHE1x8h",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/4QxfiUo90NEmUnyNHE1x8h"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 217261,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5UZA39t4lX42ApegVubl7f"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5UZA39t4lX42ApegVubl7f",
+          "id": "5UZA39t4lX42ApegVubl7f",
+          "name": "Won’t Let You Go",
+          "uri": "spotify:track:5UZA39t4lX42ApegVubl7f",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": true,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3P5KroUlTCQ6ZGViQpCixc",
+            "id": "3P5KroUlTCQ6ZGViQpCixc",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273c37aaf3d53fc4f03a03bea26",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02c37aaf3d53fc4f03a03bea26",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851c37aaf3d53fc4f03a03bea26",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Diamonds",
+            "release_date": "2021-10-08",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3P5KroUlTCQ6ZGViQpCixc",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+                },
+                "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+                "id": "2vUCVkeZjzDcaoX4gagHdV",
+                "name": "Julian Jordan",
+                "type": "artist",
+                "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0Tob4H0FLtEONHU1MjpUEp"
+                },
+                "href": "https://api.spotify.com/v1/artists/0Tob4H0FLtEONHU1MjpUEp",
+                "id": "0Tob4H0FLtEONHU1MjpUEp",
+                "name": "Tinie Tempah",
+                "type": "artist",
+                "uri": "spotify:artist:0Tob4H0FLtEONHU1MjpUEp"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3P5KroUlTCQ6ZGViQpCixc"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+              "id": "2vUCVkeZjzDcaoX4gagHdV",
+              "name": "Julian Jordan",
+              "type": "artist",
+              "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0Tob4H0FLtEONHU1MjpUEp"
+              },
+              "href": "https://api.spotify.com/v1/artists/0Tob4H0FLtEONHU1MjpUEp",
+              "id": "0Tob4H0FLtEONHU1MjpUEp",
+              "name": "Tinie Tempah",
+              "type": "artist",
+              "uri": "spotify:artist:0Tob4H0FLtEONHU1MjpUEp"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 205560,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4TA48C6sa3lRrr2hHFbePR"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4TA48C6sa3lRrr2hHFbePR",
+          "id": "4TA48C6sa3lRrr2hHFbePR",
+          "name": "Diamonds",
+          "uri": "spotify:track:4TA48C6sa3lRrr2hHFbePR",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0Lwms3Z89fmqqyVWPkZUCY",
+            "id": "0Lwms3Z89fmqqyVWPkZUCY",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273d6700754102484509cbd24fa",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02d6700754102484509cbd24fa",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851d6700754102484509cbd24fa",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Love Runs Out (feat. G-Eazy & Sasha Alex Sloan)",
+            "release_date": "2021-08-06",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0Lwms3Z89fmqqyVWPkZUCY",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/02kJSzxNuaWGqwubyUba0Z"
+                },
+                "href": "https://api.spotify.com/v1/artists/02kJSzxNuaWGqwubyUba0Z",
+                "id": "02kJSzxNuaWGqwubyUba0Z",
+                "name": "G-Eazy",
+                "type": "artist",
+                "uri": "spotify:artist:02kJSzxNuaWGqwubyUba0Z"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4xnihxcoXWK3UqryOSnbw5"
+                },
+                "href": "https://api.spotify.com/v1/artists/4xnihxcoXWK3UqryOSnbw5",
+                "id": "4xnihxcoXWK3UqryOSnbw5",
+                "name": "Sasha Alex Sloan",
+                "type": "artist",
+                "uri": "spotify:artist:4xnihxcoXWK3UqryOSnbw5"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0Lwms3Z89fmqqyVWPkZUCY"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/02kJSzxNuaWGqwubyUba0Z"
+              },
+              "href": "https://api.spotify.com/v1/artists/02kJSzxNuaWGqwubyUba0Z",
+              "id": "02kJSzxNuaWGqwubyUba0Z",
+              "name": "G-Eazy",
+              "type": "artist",
+              "uri": "spotify:artist:02kJSzxNuaWGqwubyUba0Z"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4xnihxcoXWK3UqryOSnbw5"
+              },
+              "href": "https://api.spotify.com/v1/artists/4xnihxcoXWK3UqryOSnbw5",
+              "id": "4xnihxcoXWK3UqryOSnbw5",
+              "name": "Sasha Alex Sloan",
+              "type": "artist",
+              "uri": "spotify:artist:4xnihxcoXWK3UqryOSnbw5"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 164166,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3jbAzLVcHiI5hYSkcKe1Ty"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3jbAzLVcHiI5hYSkcKe1Ty",
+          "id": "3jbAzLVcHiI5hYSkcKe1Ty",
+          "name": "Love Runs Out (feat. G-Eazy & Sasha Alex Sloan)",
+          "uri": "spotify:track:3jbAzLVcHiI5hYSkcKe1Ty",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/06RhAj4FSp8YlDyrxulgbt",
+            "id": "06RhAj4FSp8YlDyrxulgbt",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2737ee3db50ca312ab67cdeb24f",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e027ee3db50ca312ab67cdeb24f",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048517ee3db50ca312ab67cdeb24f",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "We Are The People (feat. Bono & The Edge) [Official UEFA EURO 2020 Song]",
+            "release_date": "2021-05-13",
+            "release_date_precision": "day",
+            "uri": "spotify:album:06RhAj4FSp8YlDyrxulgbt",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0m2Wc2gfNUWaAuBK7URPIJ"
+                },
+                "href": "https://api.spotify.com/v1/artists/0m2Wc2gfNUWaAuBK7URPIJ",
+                "id": "0m2Wc2gfNUWaAuBK7URPIJ",
+                "name": "Bono",
+                "type": "artist",
+                "uri": "spotify:artist:0m2Wc2gfNUWaAuBK7URPIJ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1X8wFHJFucBUmBc7spQ4jP"
+                },
+                "href": "https://api.spotify.com/v1/artists/1X8wFHJFucBUmBc7spQ4jP",
+                "id": "1X8wFHJFucBUmBc7spQ4jP",
+                "name": "The Edge",
+                "type": "artist",
+                "uri": "spotify:artist:1X8wFHJFucBUmBc7spQ4jP"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/06RhAj4FSp8YlDyrxulgbt"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0m2Wc2gfNUWaAuBK7URPIJ"
+              },
+              "href": "https://api.spotify.com/v1/artists/0m2Wc2gfNUWaAuBK7URPIJ",
+              "id": "0m2Wc2gfNUWaAuBK7URPIJ",
+              "name": "Bono",
+              "type": "artist",
+              "uri": "spotify:artist:0m2Wc2gfNUWaAuBK7URPIJ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1X8wFHJFucBUmBc7spQ4jP"
+              },
+              "href": "https://api.spotify.com/v1/artists/1X8wFHJFucBUmBc7spQ4jP",
+              "id": "1X8wFHJFucBUmBc7spQ4jP",
+              "name": "The Edge",
+              "type": "artist",
+              "uri": "spotify:artist:1X8wFHJFucBUmBc7spQ4jP"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 217000,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2iL0W5qi0ivZ9WRXbZ74cS"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2iL0W5qi0ivZ9WRXbZ74cS",
+          "id": "2iL0W5qi0ivZ9WRXbZ74cS",
+          "name": "We Are The People (feat. Bono & The Edge) - Official UEFA EURO 2020 Song",
+          "uri": "spotify:track:2iL0W5qi0ivZ9WRXbZ74cS",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/4Y3TDAf1jKhdithIywJKCb",
+            "id": "4Y3TDAf1jKhdithIywJKCb",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2731f7400679ae556454b6947e3",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e021f7400679ae556454b6947e3",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048511f7400679ae556454b6947e3",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "We Are The People (feat. Bono & The Edge) [Official UEFA EURO 2020 Song]",
+            "release_date": "2021-06-18",
+            "release_date_precision": "day",
+            "uri": "spotify:album:4Y3TDAf1jKhdithIywJKCb",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0m2Wc2gfNUWaAuBK7URPIJ"
+                },
+                "href": "https://api.spotify.com/v1/artists/0m2Wc2gfNUWaAuBK7URPIJ",
+                "id": "0m2Wc2gfNUWaAuBK7URPIJ",
+                "name": "Bono",
+                "type": "artist",
+                "uri": "spotify:artist:0m2Wc2gfNUWaAuBK7URPIJ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1X8wFHJFucBUmBc7spQ4jP"
+                },
+                "href": "https://api.spotify.com/v1/artists/1X8wFHJFucBUmBc7spQ4jP",
+                "id": "1X8wFHJFucBUmBc7spQ4jP",
+                "name": "The Edge",
+                "type": "artist",
+                "uri": "spotify:artist:1X8wFHJFucBUmBc7spQ4jP"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/4Y3TDAf1jKhdithIywJKCb"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0m2Wc2gfNUWaAuBK7URPIJ"
+              },
+              "href": "https://api.spotify.com/v1/artists/0m2Wc2gfNUWaAuBK7URPIJ",
+              "id": "0m2Wc2gfNUWaAuBK7URPIJ",
+              "name": "Bono",
+              "type": "artist",
+              "uri": "spotify:artist:0m2Wc2gfNUWaAuBK7URPIJ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1X8wFHJFucBUmBc7spQ4jP"
+              },
+              "href": "https://api.spotify.com/v1/artists/1X8wFHJFucBUmBc7spQ4jP",
+              "id": "1X8wFHJFucBUmBc7spQ4jP",
+              "name": "The Edge",
+              "type": "artist",
+              "uri": "spotify:artist:1X8wFHJFucBUmBc7spQ4jP"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 223333,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5J8Ky3NNT98Z8Mp1YQTDCZ"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5J8Ky3NNT98Z8Mp1YQTDCZ",
+          "id": "5J8Ky3NNT98Z8Mp1YQTDCZ",
+          "name": "We Are The People (Martin Garrix Remix) (feat. Bono & The Edge) - Official UEFA EURO 2020 Song",
+          "uri": "spotify:track:5J8Ky3NNT98Z8Mp1YQTDCZ",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5s55A56E4N7390TTEUzwKN",
+            "id": "5s55A56E4N7390TTEUzwKN",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273c3d71b0a03685f0c4c052f38",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02c3d71b0a03685f0c4c052f38",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851c3d71b0a03685f0c4c052f38",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Pressure (feat. Tove Lo)",
+            "release_date": "2021-02-05",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5s55A56E4N7390TTEUzwKN",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4NHQUGzhtTLFvgF5SZesLK"
+                },
+                "href": "https://api.spotify.com/v1/artists/4NHQUGzhtTLFvgF5SZesLK",
+                "id": "4NHQUGzhtTLFvgF5SZesLK",
+                "name": "Tove Lo",
+                "type": "artist",
+                "uri": "spotify:artist:4NHQUGzhtTLFvgF5SZesLK"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5s55A56E4N7390TTEUzwKN"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4NHQUGzhtTLFvgF5SZesLK"
+              },
+              "href": "https://api.spotify.com/v1/artists/4NHQUGzhtTLFvgF5SZesLK",
+              "id": "4NHQUGzhtTLFvgF5SZesLK",
+              "name": "Tove Lo",
+              "type": "artist",
+              "uri": "spotify:artist:4NHQUGzhtTLFvgF5SZesLK"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 144391,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4ga4WvRNhMsIL38pkBbnIN"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4ga4WvRNhMsIL38pkBbnIN",
+          "id": "4ga4WvRNhMsIL38pkBbnIN",
+          "name": "Pressure (feat. Tove Lo)",
+          "uri": "spotify:track:4ga4WvRNhMsIL38pkBbnIN",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5hf2mjKAMnImszlKbjoPJM",
+            "id": "5hf2mjKAMnImszlKbjoPJM",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27377f90ca08f4f9e95c22724c6",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0277f90ca08f4f9e95c22724c6",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485177f90ca08f4f9e95c22724c6",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Fire (feat. Elderbrook) [KAIOS Remix]",
+            "release_date": "2021-01-15",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5hf2mjKAMnImszlKbjoPJM",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5qTx6amAEpOiXxb6KQjquZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/5qTx6amAEpOiXxb6KQjquZ",
+                "id": "5qTx6amAEpOiXxb6KQjquZ",
+                "name": "Ytram",
+                "type": "artist",
+                "uri": "spotify:artist:5qTx6amAEpOiXxb6KQjquZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2vf4pRsEY6LpL5tKmqWb64"
+                },
+                "href": "https://api.spotify.com/v1/artists/2vf4pRsEY6LpL5tKmqWb64",
+                "id": "2vf4pRsEY6LpL5tKmqWb64",
+                "name": "Elderbrook",
+                "type": "artist",
+                "uri": "spotify:artist:2vf4pRsEY6LpL5tKmqWb64"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5hf2mjKAMnImszlKbjoPJM"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5qTx6amAEpOiXxb6KQjquZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/5qTx6amAEpOiXxb6KQjquZ",
+              "id": "5qTx6amAEpOiXxb6KQjquZ",
+              "name": "Ytram",
+              "type": "artist",
+              "uri": "spotify:artist:5qTx6amAEpOiXxb6KQjquZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vf4pRsEY6LpL5tKmqWb64"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vf4pRsEY6LpL5tKmqWb64",
+              "id": "2vf4pRsEY6LpL5tKmqWb64",
+              "name": "Elderbrook",
+              "type": "artist",
+              "uri": "spotify:artist:2vf4pRsEY6LpL5tKmqWb64"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4FIp9j5zuY5udKxPzCa5M7"
+              },
+              "href": "https://api.spotify.com/v1/artists/4FIp9j5zuY5udKxPzCa5M7",
+              "id": "4FIp9j5zuY5udKxPzCa5M7",
+              "name": "KAIOS",
+              "type": "artist",
+              "uri": "spotify:artist:4FIp9j5zuY5udKxPzCa5M7"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 401904,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5lYtdxQKPLUHA3tKXb7yyx"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5lYtdxQKPLUHA3tKXb7yyx",
+          "id": "5lYtdxQKPLUHA3tKXb7yyx",
+          "name": "Fire (feat. Elderbrook) - KAIOS Remix",
+          "uri": "spotify:track:5lYtdxQKPLUHA3tKXb7yyx",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/5PAmbnJ63zag2pdfYAj9mD",
+            "id": "5PAmbnJ63zag2pdfYAj9mD",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739cdce22ffebe97bdc76bdedd",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029cdce22ffebe97bdc76bdedd",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519cdce22ffebe97bdc76bdedd",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Alive",
+            "release_date": "2020-12-17",
+            "release_date_precision": "day",
+            "uri": "spotify:album:5PAmbnJ63zag2pdfYAj9mD",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5qTx6amAEpOiXxb6KQjquZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/5qTx6amAEpOiXxb6KQjquZ",
+                "id": "5qTx6amAEpOiXxb6KQjquZ",
+                "name": "Ytram",
+                "type": "artist",
+                "uri": "spotify:artist:5qTx6amAEpOiXxb6KQjquZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/6Mek67pKmBw5N3FZnAc2J8"
+                },
+                "href": "https://api.spotify.com/v1/artists/6Mek67pKmBw5N3FZnAc2J8",
+                "id": "6Mek67pKmBw5N3FZnAc2J8",
+                "name": "Citadelle",
+                "type": "artist",
+                "uri": "spotify:artist:6Mek67pKmBw5N3FZnAc2J8"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/5PAmbnJ63zag2pdfYAj9mD"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5qTx6amAEpOiXxb6KQjquZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/5qTx6amAEpOiXxb6KQjquZ",
+              "id": "5qTx6amAEpOiXxb6KQjquZ",
+              "name": "Ytram",
+              "type": "artist",
+              "uri": "spotify:artist:5qTx6amAEpOiXxb6KQjquZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6Mek67pKmBw5N3FZnAc2J8"
+              },
+              "href": "https://api.spotify.com/v1/artists/6Mek67pKmBw5N3FZnAc2J8",
+              "id": "6Mek67pKmBw5N3FZnAc2J8",
+              "name": "Citadelle",
+              "type": "artist",
+              "uri": "spotify:artist:6Mek67pKmBw5N3FZnAc2J8"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 168319,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3IaDHisoQv2Iri6wj57jkZ"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3IaDHisoQv2Iri6wj57jkZ",
+          "id": "3IaDHisoQv2Iri6wj57jkZ",
+          "name": "Alive",
+          "uri": "spotify:track:3IaDHisoQv2Iri6wj57jkZ",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1T7yxksU7XWdi3qpW9eWYC",
+            "id": "1T7yxksU7XWdi3qpW9eWYC",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273d7b926668ccf469c1de40129",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02d7b926668ccf469c1de40129",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851d7b926668ccf469c1de40129",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Fire (with Elderbrook)",
+            "release_date": "2020-09-04",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1T7yxksU7XWdi3qpW9eWYC",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5qTx6amAEpOiXxb6KQjquZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/5qTx6amAEpOiXxb6KQjquZ",
+                "id": "5qTx6amAEpOiXxb6KQjquZ",
+                "name": "Ytram",
+                "type": "artist",
+                "uri": "spotify:artist:5qTx6amAEpOiXxb6KQjquZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2vf4pRsEY6LpL5tKmqWb64"
+                },
+                "href": "https://api.spotify.com/v1/artists/2vf4pRsEY6LpL5tKmqWb64",
+                "id": "2vf4pRsEY6LpL5tKmqWb64",
+                "name": "Elderbrook",
+                "type": "artist",
+                "uri": "spotify:artist:2vf4pRsEY6LpL5tKmqWb64"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1T7yxksU7XWdi3qpW9eWYC"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5qTx6amAEpOiXxb6KQjquZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/5qTx6amAEpOiXxb6KQjquZ",
+              "id": "5qTx6amAEpOiXxb6KQjquZ",
+              "name": "Ytram",
+              "type": "artist",
+              "uri": "spotify:artist:5qTx6amAEpOiXxb6KQjquZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vf4pRsEY6LpL5tKmqWb64"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vf4pRsEY6LpL5tKmqWb64",
+              "id": "2vf4pRsEY6LpL5tKmqWb64",
+              "name": "Elderbrook",
+              "type": "artist",
+              "uri": "spotify:artist:2vf4pRsEY6LpL5tKmqWb64"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 163968,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5HFPK8mcO6BGPZNeZPZI5L"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5HFPK8mcO6BGPZNeZPZI5L",
+          "id": "5HFPK8mcO6BGPZNeZPZI5L",
+          "name": "Fire (with Elderbrook)",
+          "uri": "spotify:track:5HFPK8mcO6BGPZNeZPZI5L",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/4fz1NS3WiDHT4CcTU8faik",
+            "id": "4fz1NS3WiDHT4CcTU8faik",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273d92846391edf6d2fea4895a4",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02d92846391edf6d2fea4895a4",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851d92846391edf6d2fea4895a4",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Higher Ground (Ferreck Dawn Remix)",
+            "release_date": "2020-08-07",
+            "release_date_precision": "day",
+            "uri": "spotify:album:4fz1NS3WiDHT4CcTU8faik",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/4fz1NS3WiDHT4CcTU8faik"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3cnAJv9gydgm52KFIsdvO8"
+              },
+              "href": "https://api.spotify.com/v1/artists/3cnAJv9gydgm52KFIsdvO8",
+              "id": "3cnAJv9gydgm52KFIsdvO8",
+              "name": "Ferreck Dawn",
+              "type": "artist",
+              "uri": "spotify:artist:3cnAJv9gydgm52KFIsdvO8"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 189350,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6UjCVZIwjnElTe8zobRtZz"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6UjCVZIwjnElTe8zobRtZz",
+          "id": "6UjCVZIwjnElTe8zobRtZz",
+          "name": "Higher Ground - Ferreck Dawn Remix",
+          "uri": "spotify:track:6UjCVZIwjnElTe8zobRtZz",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6EMRe0OaGtgwvLyyfg5yMf",
+            "id": "6EMRe0OaGtgwvLyyfg5yMf",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2730c91e43887307d573af11500",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e020c91e43887307d573af11500",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048510c91e43887307d573af11500",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Higher Ground (feat. John Martin) [Remixes]",
+            "release_date": "2020-08-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6EMRe0OaGtgwvLyyfg5yMf",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6EMRe0OaGtgwvLyyfg5yMf"
+            },
+            "total_tracks": 4
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 221760,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6mKJp8IRfbgknChwXNH2Dk"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6mKJp8IRfbgknChwXNH2Dk",
+          "id": "6mKJp8IRfbgknChwXNH2Dk",
+          "name": "Higher Ground - DubVision Remix",
+          "uri": "spotify:track:6mKJp8IRfbgknChwXNH2Dk",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2wfc0nU4LeUtwyhbkOE6iH",
+            "id": "2wfc0nU4LeUtwyhbkOE6iH",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27326369d51be4bdab3bbc57383",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0226369d51be4bdab3bbc57383",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485126369d51be4bdab3bbc57383",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Higher Ground (feat. John Martin)",
+            "release_date": "2020-05-14",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2wfc0nU4LeUtwyhbkOE6iH",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+                },
+                "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+                "id": "2auikkNYqigWStoHWK1Grq",
+                "name": "John Martin",
+                "type": "artist",
+                "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2wfc0nU4LeUtwyhbkOE6iH"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2auikkNYqigWStoHWK1Grq"
+              },
+              "href": "https://api.spotify.com/v1/artists/2auikkNYqigWStoHWK1Grq",
+              "id": "2auikkNYqigWStoHWK1Grq",
+              "name": "John Martin",
+              "type": "artist",
+              "uri": "spotify:artist:2auikkNYqigWStoHWK1Grq"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 206279,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0rohJsT6NWsThpukt0Xxdc"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0rohJsT6NWsThpukt0Xxdc",
+          "id": "0rohJsT6NWsThpukt0Xxdc",
+          "name": "Higher Ground (feat. John Martin)",
+          "uri": "spotify:track:0rohJsT6NWsThpukt0Xxdc",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7JUg79xvtX4JIvoZ6bNf7P",
+            "id": "7JUg79xvtX4JIvoZ6bNf7P",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273ab3cb85f2d6c24a95613b120",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ab3cb85f2d6c24a95613b120",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851ab3cb85f2d6c24a95613b120",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane) [Remixes]",
+            "release_date": "2020-05-01",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7JUg79xvtX4JIvoZ6bNf7P",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7JUg79xvtX4JIvoZ6bNf7P"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XonXgjEAAXVl0WKLF1Z4g"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XonXgjEAAXVl0WKLF1Z4g",
+              "id": "3XonXgjEAAXVl0WKLF1Z4g",
+              "name": "Sidney Samson",
+              "type": "artist",
+              "uri": "spotify:artist:3XonXgjEAAXVl0WKLF1Z4g"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 168870,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6hByDhfa9c4osUufhP24qm"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6hByDhfa9c4osUufhP24qm",
+          "id": "6hByDhfa9c4osUufhP24qm",
+          "name": "Drown (feat. Clinton Kane) - Sidney Samson Remix",
+          "uri": "spotify:track:6hByDhfa9c4osUufhP24qm",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7JUg79xvtX4JIvoZ6bNf7P",
+            "id": "7JUg79xvtX4JIvoZ6bNf7P",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273ab3cb85f2d6c24a95613b120",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ab3cb85f2d6c24a95613b120",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851ab3cb85f2d6c24a95613b120",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane) [Remixes]",
+            "release_date": "2020-05-01",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7JUg79xvtX4JIvoZ6bNf7P",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7JUg79xvtX4JIvoZ6bNf7P"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3ZPRZDAAuBrvx1tsIjeFxh"
+              },
+              "href": "https://api.spotify.com/v1/artists/3ZPRZDAAuBrvx1tsIjeFxh",
+              "id": "3ZPRZDAAuBrvx1tsIjeFxh",
+              "name": "Pat Lok",
+              "type": "artist",
+              "uri": "spotify:artist:3ZPRZDAAuBrvx1tsIjeFxh"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 4,
+          "duration_ms": 228000,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7EybajZlpD6Sms7D2oy7Ng"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7EybajZlpD6Sms7D2oy7Ng",
+          "id": "7EybajZlpD6Sms7D2oy7Ng",
+          "name": "Drown (feat. Clinton Kane) - Pat Lok Remix",
+          "uri": "spotify:track:7EybajZlpD6Sms7D2oy7Ng",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7zzQIYXxfr0A8mg1hhd2SQ",
+            "id": "7zzQIYXxfr0A8mg1hhd2SQ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273a7a1cec7a440de186fff2af3",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02a7a1cec7a440de186fff2af3",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851a7a1cec7a440de186fff2af3",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane) [The Subculture Remix]",
+            "release_date": "2020-04-17",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7zzQIYXxfr0A8mg1hhd2SQ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3ZkyzF84LNx4DAarg3DHxY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3ZkyzF84LNx4DAarg3DHxY",
+                "id": "3ZkyzF84LNx4DAarg3DHxY",
+                "name": "The Subculture",
+                "type": "artist",
+                "uri": "spotify:artist:3ZkyzF84LNx4DAarg3DHxY"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7zzQIYXxfr0A8mg1hhd2SQ"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3ZkyzF84LNx4DAarg3DHxY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3ZkyzF84LNx4DAarg3DHxY",
+              "id": "3ZkyzF84LNx4DAarg3DHxY",
+              "name": "The Subculture",
+              "type": "artist",
+              "uri": "spotify:artist:3ZkyzF84LNx4DAarg3DHxY"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 199354,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/6QI017tvDtPq0ZrPWAR9ys"
+          },
+          "href": "https://api.spotify.com/v1/tracks/6QI017tvDtPq0ZrPWAR9ys",
+          "id": "6QI017tvDtPq0ZrPWAR9ys",
+          "name": "Drown (feat. Clinton Kane) - The Subculture Remix",
+          "uri": "spotify:track:6QI017tvDtPq0ZrPWAR9ys",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7LXjYzzeEeesABVJV8Qfk2",
+            "id": "7LXjYzzeEeesABVJV8Qfk2",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273787172d1d35762b4b30aba19",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02787172d1d35762b4b30aba19",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851787172d1d35762b4b30aba19",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane) [Alle Farben Remix]",
+            "release_date": "2020-04-10",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7LXjYzzeEeesABVJV8Qfk2",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/61ipISvUVa5LkJlKZnm3Oo"
+                },
+                "href": "https://api.spotify.com/v1/artists/61ipISvUVa5LkJlKZnm3Oo",
+                "id": "61ipISvUVa5LkJlKZnm3Oo",
+                "name": "Alle Farben",
+                "type": "artist",
+                "uri": "spotify:artist:61ipISvUVa5LkJlKZnm3Oo"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7LXjYzzeEeesABVJV8Qfk2"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/61ipISvUVa5LkJlKZnm3Oo"
+              },
+              "href": "https://api.spotify.com/v1/artists/61ipISvUVa5LkJlKZnm3Oo",
+              "id": "61ipISvUVa5LkJlKZnm3Oo",
+              "name": "Alle Farben",
+              "type": "artist",
+              "uri": "spotify:artist:61ipISvUVa5LkJlKZnm3Oo"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 169270,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3L3s97R0738xGQ2VqB12qo"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3L3s97R0738xGQ2VqB12qo",
+          "id": "3L3s97R0738xGQ2VqB12qo",
+          "name": "Drown (feat. Clinton Kane) - Alle Farben Remix",
+          "uri": "spotify:track:3L3s97R0738xGQ2VqB12qo",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0yyVHA6DKNQSfYMVuvjuza",
+            "id": "0yyVHA6DKNQSfYMVuvjuza",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2738e1e58c5c4fea8706bba6810",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e028e1e58c5c4fea8706bba6810",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048518e1e58c5c4fea8706bba6810",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane) [Nicky Romero Remix]",
+            "release_date": "2020-04-03",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0yyVHA6DKNQSfYMVuvjuza",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+                },
+                "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+                "id": "5ChF3i92IPZHduM7jN3dpg",
+                "name": "Nicky Romero",
+                "type": "artist",
+                "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0yyVHA6DKNQSfYMVuvjuza"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5ChF3i92IPZHduM7jN3dpg"
+              },
+              "href": "https://api.spotify.com/v1/artists/5ChF3i92IPZHduM7jN3dpg",
+              "id": "5ChF3i92IPZHduM7jN3dpg",
+              "name": "Nicky Romero",
+              "type": "artist",
+              "uri": "spotify:artist:5ChF3i92IPZHduM7jN3dpg"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 187380,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5aRwLXpWjgXmwoJvXoYvCq"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5aRwLXpWjgXmwoJvXoYvCq",
+          "id": "5aRwLXpWjgXmwoJvXoYvCq",
+          "name": "Drown (feat. Clinton Kane) - Nicky Romero Remix",
+          "uri": "spotify:track:5aRwLXpWjgXmwoJvXoYvCq",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2tSAddvD0pYgsozLeFuHP6",
+            "id": "2tSAddvD0pYgsozLeFuHP6",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273babb723e2142477ca309bd58",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02babb723e2142477ca309bd58",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851babb723e2142477ca309bd58",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane) [Matroda Remix]",
+            "release_date": "2020-03-27",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2tSAddvD0pYgsozLeFuHP6",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2tSAddvD0pYgsozLeFuHP6"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/45lcbTsX07JWzmTIjcdyBz"
+              },
+              "href": "https://api.spotify.com/v1/artists/45lcbTsX07JWzmTIjcdyBz",
+              "id": "45lcbTsX07JWzmTIjcdyBz",
+              "name": "Matroda",
+              "type": "artist",
+              "uri": "spotify:artist:45lcbTsX07JWzmTIjcdyBz"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 231604,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0Eo4ybyABVbzEefKptQQWo"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0Eo4ybyABVbzEefKptQQWo",
+          "id": "0Eo4ybyABVbzEefKptQQWo",
+          "name": "Drown (feat. Clinton Kane) - Matroda Remix",
+          "uri": "spotify:track:0Eo4ybyABVbzEefKptQQWo",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/7rU4vsRIhRRfMt3qy6ADND",
+            "id": "7rU4vsRIhRRfMt3qy6ADND",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27337f0179db847d662dfdfa0e3",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0237f0179db847d662dfdfa0e3",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485137f0179db847d662dfdfa0e3",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Drown (feat. Clinton Kane)",
+            "release_date": "2020-02-27",
+            "release_date_precision": "day",
+            "uri": "spotify:album:7rU4vsRIhRRfMt3qy6ADND",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+                },
+                "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+                "id": "7okSU80WTrn4LXlyXYbX3P",
+                "name": "Clinton Kane",
+                "type": "artist",
+                "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/7rU4vsRIhRRfMt3qy6ADND"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7okSU80WTrn4LXlyXYbX3P"
+              },
+              "href": "https://api.spotify.com/v1/artists/7okSU80WTrn4LXlyXYbX3P",
+              "id": "7okSU80WTrn4LXlyXYbX3P",
+              "name": "Clinton Kane",
+              "type": "artist",
+              "uri": "spotify:artist:7okSU80WTrn4LXlyXYbX3P"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 174062,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4RVtBlHFKj51Ipvpfv5ER4"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4RVtBlHFKj51Ipvpfv5ER4",
+          "id": "4RVtBlHFKj51Ipvpfv5ER4",
+          "name": "Drown (feat. Clinton Kane)",
+          "uri": "spotify:track:4RVtBlHFKj51Ipvpfv5ER4",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/21ysWUeoQEhTtNuPggWbQt",
+            "id": "21ysWUeoQEhTtNuPggWbQt",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2738b77f9a2f5a86cf358bba4f3",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e028b77f9a2f5a86cf358bba4f3",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048518b77f9a2f5a86cf358bba4f3",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Used To Love (Acoustic Version)",
+            "release_date": "2020-02-14",
+            "release_date_precision": "day",
+            "uri": "spotify:album:21ysWUeoQEhTtNuPggWbQt",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+                },
+                "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+                "id": "3QSQFmccmX81fWCUSPTS7y",
+                "name": "Dean Lewis",
+                "type": "artist",
+                "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/21ysWUeoQEhTtNuPggWbQt"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+              },
+              "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+              "id": "3QSQFmccmX81fWCUSPTS7y",
+              "name": "Dean Lewis",
+              "type": "artist",
+              "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 211308,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3diDPfrvqfnXcCIYzU11eP"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3diDPfrvqfnXcCIYzU11eP",
+          "id": "3diDPfrvqfnXcCIYzU11eP",
+          "name": "Used To Love - Acoustic Version",
+          "uri": "spotify:track:3diDPfrvqfnXcCIYzU11eP",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2BxWklE9D6hPhvPgcvLWtZ",
+            "id": "2BxWklE9D6hPhvPgcvLWtZ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2738778f5322c5c841b8ff4c39e",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e028778f5322c5c841b8ff4c39e",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048518778f5322c5c841b8ff4c39e",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Hold On (feat. Michel Zitron)",
+            "release_date": "2019-12-27",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2BxWklE9D6hPhvPgcvLWtZ",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/0SiA0xtHw1lnSXRf1S7jjw"
+                },
+                "href": "https://api.spotify.com/v1/artists/0SiA0xtHw1lnSXRf1S7jjw",
+                "id": "0SiA0xtHw1lnSXRf1S7jjw",
+                "name": "Michel Zitron",
+                "type": "artist",
+                "uri": "spotify:artist:0SiA0xtHw1lnSXRf1S7jjw"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2BxWklE9D6hPhvPgcvLWtZ"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0SiA0xtHw1lnSXRf1S7jjw"
+              },
+              "href": "https://api.spotify.com/v1/artists/0SiA0xtHw1lnSXRf1S7jjw",
+              "id": "0SiA0xtHw1lnSXRf1S7jjw",
+              "name": "Michel Zitron",
+              "type": "artist",
+              "uri": "spotify:artist:0SiA0xtHw1lnSXRf1S7jjw"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 244453,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/22zxLxXlXrBIm7XaazHNrg"
+          },
+          "href": "https://api.spotify.com/v1/tracks/22zxLxXlXrBIm7XaazHNrg",
+          "id": "22zxLxXlXrBIm7XaazHNrg",
+          "name": "Hold On (feat. Michel Zitron)",
+          "uri": "spotify:track:22zxLxXlXrBIm7XaazHNrg",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3XINWZaloea97SIRiyTJxX"
+              },
+              "href": "https://api.spotify.com/v1/artists/3XINWZaloea97SIRiyTJxX",
+              "id": "3XINWZaloea97SIRiyTJxX",
+              "name": "DubVision",
+              "type": "artist",
+              "uri": "spotify:artist:3XINWZaloea97SIRiyTJxX"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 239062,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0mV5JWhyUFANd9qpwLkM8d"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0mV5JWhyUFANd9qpwLkM8d",
+          "id": "0mV5JWhyUFANd9qpwLkM8d",
+          "name": "No Sleep (feat. Bonn) - DubVision Remix",
+          "uri": "spotify:track:0mV5JWhyUFANd9qpwLkM8d",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7J7YzKnvAyEmHCg7LGWW0G"
+              },
+              "href": "https://api.spotify.com/v1/artists/7J7YzKnvAyEmHCg7LGWW0G",
+              "id": "7J7YzKnvAyEmHCg7LGWW0G",
+              "name": "Alex Aris",
+              "type": "artist",
+              "uri": "spotify:artist:7J7YzKnvAyEmHCg7LGWW0G"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7LvvNoUPwTZpgXDWBRrfHg"
+              },
+              "href": "https://api.spotify.com/v1/artists/7LvvNoUPwTZpgXDWBRrfHg",
+              "id": "7LvvNoUPwTZpgXDWBRrfHg",
+              "name": "DRAMA",
+              "type": "artist",
+              "uri": "spotify:artist:7LvvNoUPwTZpgXDWBRrfHg"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 236000,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5OWrngLj7uTcicHivhY7jA"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5OWrngLj7uTcicHivhY7jA",
+          "id": "5OWrngLj7uTcicHivhY7jA",
+          "name": "Mistaken (feat. Alex Aris) - DRAMA Remix",
+          "uri": "spotify:track:5OWrngLj7uTcicHivhY7jA",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/28uJnu5EsrGml2tBd7y8ts"
+              },
+              "href": "https://api.spotify.com/v1/artists/28uJnu5EsrGml2tBd7y8ts",
+              "id": "28uJnu5EsrGml2tBd7y8ts",
+              "name": "Vintage Culture",
+              "type": "artist",
+              "uri": "spotify:artist:28uJnu5EsrGml2tBd7y8ts"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/37UXlMGND0Tr7Su43RxHQ0"
+              },
+              "href": "https://api.spotify.com/v1/artists/37UXlMGND0Tr7Su43RxHQ0",
+              "id": "37UXlMGND0Tr7Su43RxHQ0",
+              "name": "Bruno Be",
+              "type": "artist",
+              "uri": "spotify:artist:37UXlMGND0Tr7Su43RxHQ0"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 195799,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/3vWtVy3fjfNzqQh7Je4l7Z"
+          },
+          "href": "https://api.spotify.com/v1/tracks/3vWtVy3fjfNzqQh7Je4l7Z",
+          "id": "3vWtVy3fjfNzqQh7Je4l7Z",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Vintage Culture & Bruno Be Remix",
+          "uri": "spotify:track:3vWtVy3fjfNzqQh7Je4l7Z",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1NbmG1Fj64qykEcJt1d43a"
+              },
+              "href": "https://api.spotify.com/v1/artists/1NbmG1Fj64qykEcJt1d43a",
+              "id": "1NbmG1Fj64qykEcJt1d43a",
+              "name": "JRM",
+              "type": "artist",
+              "uri": "spotify:artist:1NbmG1Fj64qykEcJt1d43a"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/03MVmfitJTVJIxYmObhQn9"
+              },
+              "href": "https://api.spotify.com/v1/artists/03MVmfitJTVJIxYmObhQn9",
+              "id": "03MVmfitJTVJIxYmObhQn9",
+              "name": "Dyro",
+              "type": "artist",
+              "uri": "spotify:artist:03MVmfitJTVJIxYmObhQn9"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 4,
+          "duration_ms": 162519,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1zOzlWLFXkUrezJZOM7CX5"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1zOzlWLFXkUrezJZOM7CX5",
+          "id": "1zOzlWLFXkUrezJZOM7CX5",
+          "name": "These Are The Times (feat. JRM) - Dyro Remix",
+          "uri": "spotify:track:1zOzlWLFXkUrezJZOM7CX5",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/78KwNsjhjWzZYejeBTtsNW"
+              },
+              "href": "https://api.spotify.com/v1/artists/78KwNsjhjWzZYejeBTtsNW",
+              "id": "78KwNsjhjWzZYejeBTtsNW",
+              "name": "Silque",
+              "type": "artist",
+              "uri": "spotify:artist:78KwNsjhjWzZYejeBTtsNW"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 5,
+          "duration_ms": 186720,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0JQBgYsrpJmmKN40ptiBPS"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0JQBgYsrpJmmKN40ptiBPS",
+          "id": "0JQBgYsrpJmmKN40ptiBPS",
+          "name": "Home (feat. Bonn) - Silque Remix",
+          "uri": "spotify:track:0JQBgYsrpJmmKN40ptiBPS",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+              },
+              "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+              "id": "3QSQFmccmX81fWCUSPTS7y",
+              "name": "Dean Lewis",
+              "type": "artist",
+              "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1eOOXqRHILTxqrEUAYyQU0"
+              },
+              "href": "https://api.spotify.com/v1/artists/1eOOXqRHILTxqrEUAYyQU0",
+              "id": "1eOOXqRHILTxqrEUAYyQU0",
+              "name": "Bart B More",
+              "type": "artist",
+              "uri": "spotify:artist:1eOOXqRHILTxqrEUAYyQU0"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 6,
+          "duration_ms": 178571,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/12Ueu4dNhQn6buHxWDsC8Q"
+          },
+          "href": "https://api.spotify.com/v1/tracks/12Ueu4dNhQn6buHxWDsC8Q",
+          "id": "12Ueu4dNhQn6buHxWDsC8Q",
+          "name": "Used To Love (with Dean Lewis) - Bart B More Remix",
+          "uri": "spotify:track:12Ueu4dNhQn6buHxWDsC8Q",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3z4efVJv1e3GmoR7PybqHR",
+            "id": "3z4efVJv1e3GmoR7PybqHR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2739d5a692b7a70508595e944ba",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e029d5a692b7a70508595e944ba",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048519d5a692b7a70508595e944ba",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "2019 Remixed",
+            "release_date": "2019-12-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3z4efVJv1e3GmoR7PybqHR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3z4efVJv1e3GmoR7PybqHR"
+            },
+            "total_tracks": 7
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/0SiA0xtHw1lnSXRf1S7jjw"
+              },
+              "href": "https://api.spotify.com/v1/artists/0SiA0xtHw1lnSXRf1S7jjw",
+              "id": "0SiA0xtHw1lnSXRf1S7jjw",
+              "name": "Michel Zitron",
+              "type": "artist",
+              "uri": "spotify:artist:0SiA0xtHw1lnSXRf1S7jjw"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2vUCVkeZjzDcaoX4gagHdV"
+              },
+              "href": "https://api.spotify.com/v1/artists/2vUCVkeZjzDcaoX4gagHdV",
+              "id": "2vUCVkeZjzDcaoX4gagHdV",
+              "name": "Julian Jordan",
+              "type": "artist",
+              "uri": "spotify:artist:2vUCVkeZjzDcaoX4gagHdV"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 7,
+          "duration_ms": 279978,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1VLzca7LUFQxYAgEVlGeUa"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1VLzca7LUFQxYAgEVlGeUa",
+          "id": "1VLzca7LUFQxYAgEVlGeUa",
+          "name": "Hold On (feat. Michel Zitron) - Julian Jordan Remix",
+          "uri": "spotify:track:1VLzca7LUFQxYAgEVlGeUa",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6Rf09sVx3axyYeTP42EXgU",
+            "id": "6Rf09sVx3axyYeTP42EXgU",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273aa68ad51f4a3f5bb9ec64fe1",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02aa68ad51f4a3f5bb9ec64fe1",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851aa68ad51f4a3f5bb9ec64fe1",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Used To Love (with Dean Lewis) [Remixes]",
+            "release_date": "2019-12-20",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6Rf09sVx3axyYeTP42EXgU",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+                },
+                "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+                "id": "3QSQFmccmX81fWCUSPTS7y",
+                "name": "Dean Lewis",
+                "type": "artist",
+                "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6Rf09sVx3axyYeTP42EXgU"
+            },
+            "total_tracks": 3
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+              },
+              "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+              "id": "3QSQFmccmX81fWCUSPTS7y",
+              "name": "Dean Lewis",
+              "type": "artist",
+              "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/45UHclgIcRavRoRa2MET5i"
+              },
+              "href": "https://api.spotify.com/v1/artists/45UHclgIcRavRoRa2MET5i",
+              "id": "45UHclgIcRavRoRa2MET5i",
+              "name": "SWACQ",
+              "type": "artist",
+              "uri": "spotify:artist:45UHclgIcRavRoRa2MET5i"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 220800,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2vfiK6HFMl34UzBxq4NNSK"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2vfiK6HFMl34UzBxq4NNSK",
+          "id": "2vfiK6HFMl34UzBxq4NNSK",
+          "name": "Used To Love (with Dean Lewis) - SWACQ Remix",
+          "uri": "spotify:track:2vfiK6HFMl34UzBxq4NNSK",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6Rf09sVx3axyYeTP42EXgU",
+            "id": "6Rf09sVx3axyYeTP42EXgU",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273aa68ad51f4a3f5bb9ec64fe1",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02aa68ad51f4a3f5bb9ec64fe1",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851aa68ad51f4a3f5bb9ec64fe1",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Used To Love (with Dean Lewis) [Remixes]",
+            "release_date": "2019-12-20",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6Rf09sVx3axyYeTP42EXgU",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+                },
+                "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+                "id": "3QSQFmccmX81fWCUSPTS7y",
+                "name": "Dean Lewis",
+                "type": "artist",
+                "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6Rf09sVx3axyYeTP42EXgU"
+            },
+            "total_tracks": 3
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+              },
+              "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+              "id": "3QSQFmccmX81fWCUSPTS7y",
+              "name": "Dean Lewis",
+              "type": "artist",
+              "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/70c48bioArCGTsN9pH04NT"
+              },
+              "href": "https://api.spotify.com/v1/artists/70c48bioArCGTsN9pH04NT",
+              "id": "70c48bioArCGTsN9pH04NT",
+              "name": "Osrin",
+              "type": "artist",
+              "uri": "spotify:artist:70c48bioArCGTsN9pH04NT"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6pUu9y4pMmIsEre45xQaxj"
+              },
+              "href": "https://api.spotify.com/v1/artists/6pUu9y4pMmIsEre45xQaxj",
+              "id": "6pUu9y4pMmIsEre45xQaxj",
+              "name": "Beau Collins",
+              "type": "artist",
+              "uri": "spotify:artist:6pUu9y4pMmIsEre45xQaxj"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 214143,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/55L2St4kYqclPXWRKoB5OL"
+          },
+          "href": "https://api.spotify.com/v1/tracks/55L2St4kYqclPXWRKoB5OL",
+          "id": "55L2St4kYqclPXWRKoB5OL",
+          "name": "Used To Love (with Dean Lewis) - Osrin & Beau Collins Remix",
+          "uri": "spotify:track:55L2St4kYqclPXWRKoB5OL",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/6Rf09sVx3axyYeTP42EXgU",
+            "id": "6Rf09sVx3axyYeTP42EXgU",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273aa68ad51f4a3f5bb9ec64fe1",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02aa68ad51f4a3f5bb9ec64fe1",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851aa68ad51f4a3f5bb9ec64fe1",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Used To Love (with Dean Lewis) [Remixes]",
+            "release_date": "2019-12-20",
+            "release_date_precision": "day",
+            "uri": "spotify:album:6Rf09sVx3axyYeTP42EXgU",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+                },
+                "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+                "id": "3QSQFmccmX81fWCUSPTS7y",
+                "name": "Dean Lewis",
+                "type": "artist",
+                "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/6Rf09sVx3axyYeTP42EXgU"
+            },
+            "total_tracks": 3
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+              },
+              "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+              "id": "3QSQFmccmX81fWCUSPTS7y",
+              "name": "Dean Lewis",
+              "type": "artist",
+              "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/00JumPfBUZm33fTNYLJLCd"
+              },
+              "href": "https://api.spotify.com/v1/artists/00JumPfBUZm33fTNYLJLCd",
+              "id": "00JumPfBUZm33fTNYLJLCd",
+              "name": "Jimi Hyde",
+              "type": "artist",
+              "uri": "spotify:artist:00JumPfBUZm33fTNYLJLCd"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 200626,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4XCnsRNWhdpN5bQlLXBDJl"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4XCnsRNWhdpN5bQlLXBDJl",
+          "id": "4XCnsRNWhdpN5bQlLXBDJl",
+          "name": "Used To Love (with Dean Lewis) - Jimi Hyde Remix",
+          "uri": "spotify:track:4XCnsRNWhdpN5bQlLXBDJl",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/3YD1qyD9KPFzzTK1UC1Gvo",
+            "id": "3YD1qyD9KPFzzTK1UC1Gvo",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273dcc28379ce36e6fbf9a311a0",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02dcc28379ce36e6fbf9a311a0",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851dcc28379ce36e6fbf9a311a0",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Used To Love (with Dean Lewis)",
+            "release_date": "2019-10-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:3YD1qyD9KPFzzTK1UC1Gvo",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+                },
+                "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+                "id": "3QSQFmccmX81fWCUSPTS7y",
+                "name": "Dean Lewis",
+                "type": "artist",
+                "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/3YD1qyD9KPFzzTK1UC1Gvo"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3QSQFmccmX81fWCUSPTS7y"
+              },
+              "href": "https://api.spotify.com/v1/artists/3QSQFmccmX81fWCUSPTS7y",
+              "id": "3QSQFmccmX81fWCUSPTS7y",
+              "name": "Dean Lewis",
+              "type": "artist",
+              "uri": "spotify:artist:3QSQFmccmX81fWCUSPTS7y"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 236764,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7pWK1kMgHy5lNNiIfuRbkP"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7pWK1kMgHy5lNNiIfuRbkP",
+          "id": "7pWK1kMgHy5lNNiIfuRbkP",
+          "name": "Used To Love (with Dean Lewis)",
+          "uri": "spotify:track:7pWK1kMgHy5lNNiIfuRbkP",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1cL51Zp86zgzMDTXRiq8w9",
+            "id": "1cL51Zp86zgzMDTXRiq8w9",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273a76b4ef04239e66d2489b0f2",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02a76b4ef04239e66d2489b0f2",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851a76b4ef04239e66d2489b0f2",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Home (feat. Bonn)",
+            "release_date": "2019-08-16",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1cL51Zp86zgzMDTXRiq8w9",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+                },
+                "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+                "id": "7Io0XduXk7aOHFHA7sLru2",
+                "name": "Bonn",
+                "type": "artist",
+                "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1cL51Zp86zgzMDTXRiq8w9"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7Io0XduXk7aOHFHA7sLru2"
+              },
+              "href": "https://api.spotify.com/v1/artists/7Io0XduXk7aOHFHA7sLru2",
+              "id": "7Io0XduXk7aOHFHA7sLru2",
+              "name": "Bonn",
+              "type": "artist",
+              "uri": "spotify:artist:7Io0XduXk7aOHFHA7sLru2"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 239067,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4aTtHoSBB0CuQGA6vXBNyp"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4aTtHoSBB0CuQGA6vXBNyp",
+          "id": "4aTtHoSBB0CuQGA6vXBNyp",
+          "name": "Home (feat. Bonn)",
+          "uri": "spotify:track:4aTtHoSBB0CuQGA6vXBNyp",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2OkqLVAw949KZZ8lgMMIdj",
+            "id": "2OkqLVAw949KZZ8lgMMIdj",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b2736d672e1a7f9542e18d66c2cc",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e026d672e1a7f9542e18d66c2cc",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d000048516d672e1a7f9542e18d66c2cc",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "These Are The Times (feat. JRM)",
+            "release_date": "2019-07-18",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2OkqLVAw949KZZ8lgMMIdj",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1NbmG1Fj64qykEcJt1d43a"
+                },
+                "href": "https://api.spotify.com/v1/artists/1NbmG1Fj64qykEcJt1d43a",
+                "id": "1NbmG1Fj64qykEcJt1d43a",
+                "name": "JRM",
+                "type": "artist",
+                "uri": "spotify:artist:1NbmG1Fj64qykEcJt1d43a"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2OkqLVAw949KZZ8lgMMIdj"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1NbmG1Fj64qykEcJt1d43a"
+              },
+              "href": "https://api.spotify.com/v1/artists/1NbmG1Fj64qykEcJt1d43a",
+              "id": "1NbmG1Fj64qykEcJt1d43a",
+              "name": "JRM",
+              "type": "artist",
+              "uri": "spotify:artist:1NbmG1Fj64qykEcJt1d43a"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 188656,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/5YN0zHycJ0Yxz31A5QsVov"
+          },
+          "href": "https://api.spotify.com/v1/tracks/5YN0zHycJ0Yxz31A5QsVov",
+          "id": "5YN0zHycJ0Yxz31A5QsVov",
+          "name": "These Are The Times (feat. JRM)",
+          "uri": "spotify:track:5YN0zHycJ0Yxz31A5QsVov",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2vx3BtBMn8Ed3ygEg1OT2t",
+            "id": "2vx3BtBMn8Ed3ygEg1OT2t",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27385df7b8e4cfe789fffe85364",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0285df7b8e4cfe789fffe85364",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485185df7b8e4cfe789fffe85364",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) [Remixes]",
+            "release_date": "2019-07-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2vx3BtBMn8Ed3ygEg1OT2t",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+                "id": "3JhNCzhSMTxs9WLGJJxWOY",
+                "name": "Macklemore",
+                "type": "artist",
+                "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+                "id": "4UXqAaa6dQYAk18Lv7PEgX",
+                "name": "Fall Out Boy",
+                "type": "artist",
+                "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2vx3BtBMn8Ed3ygEg1OT2t"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2o5jDhtHVPhrJdv3cEQ99Z"
+              },
+              "href": "https://api.spotify.com/v1/artists/2o5jDhtHVPhrJdv3cEQ99Z",
+              "id": "2o5jDhtHVPhrJdv3cEQ99Z",
+              "name": "Tiësto",
+              "type": "artist",
+              "uri": "spotify:artist:2o5jDhtHVPhrJdv3cEQ99Z"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 255238,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/55nMnifaQWKe3f9cbwOXwx"
+          },
+          "href": "https://api.spotify.com/v1/tracks/55nMnifaQWKe3f9cbwOXwx",
+          "id": "55nMnifaQWKe3f9cbwOXwx",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix",
+          "uri": "spotify:track:55nMnifaQWKe3f9cbwOXwx",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2vx3BtBMn8Ed3ygEg1OT2t",
+            "id": "2vx3BtBMn8Ed3ygEg1OT2t",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27385df7b8e4cfe789fffe85364",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0285df7b8e4cfe789fffe85364",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485185df7b8e4cfe789fffe85364",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) [Remixes]",
+            "release_date": "2019-07-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2vx3BtBMn8Ed3ygEg1OT2t",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+                "id": "3JhNCzhSMTxs9WLGJJxWOY",
+                "name": "Macklemore",
+                "type": "artist",
+                "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+                "id": "4UXqAaa6dQYAk18Lv7PEgX",
+                "name": "Fall Out Boy",
+                "type": "artist",
+                "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2vx3BtBMn8Ed3ygEg1OT2t"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7f5Zgnp2spUuuzKplmRkt7"
+              },
+              "href": "https://api.spotify.com/v1/artists/7f5Zgnp2spUuuzKplmRkt7",
+              "id": "7f5Zgnp2spUuuzKplmRkt7",
+              "name": "Lost Frequencies",
+              "type": "artist",
+              "uri": "spotify:artist:7f5Zgnp2spUuuzKplmRkt7"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 204662,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4y5aj99vmiUJWQH933sqZ7"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4y5aj99vmiUJWQH933sqZ7",
+          "id": "4y5aj99vmiUJWQH933sqZ7",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Lost Frequencies Remix",
+          "uri": "spotify:track:4y5aj99vmiUJWQH933sqZ7",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2vx3BtBMn8Ed3ygEg1OT2t",
+            "id": "2vx3BtBMn8Ed3ygEg1OT2t",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27385df7b8e4cfe789fffe85364",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0285df7b8e4cfe789fffe85364",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485185df7b8e4cfe789fffe85364",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) [Remixes]",
+            "release_date": "2019-07-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2vx3BtBMn8Ed3ygEg1OT2t",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+                "id": "3JhNCzhSMTxs9WLGJJxWOY",
+                "name": "Macklemore",
+                "type": "artist",
+                "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+                "id": "4UXqAaa6dQYAk18Lv7PEgX",
+                "name": "Fall Out Boy",
+                "type": "artist",
+                "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2vx3BtBMn8Ed3ygEg1OT2t"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7aUSp5cOZlwEtd5zPC795k"
+              },
+              "href": "https://api.spotify.com/v1/artists/7aUSp5cOZlwEtd5zPC795k",
+              "id": "7aUSp5cOZlwEtd5zPC795k",
+              "name": "Haywyre",
+              "type": "artist",
+              "uri": "spotify:artist:7aUSp5cOZlwEtd5zPC795k"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 3,
+          "duration_ms": 229743,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4yPWiRV6FrQTGm6qBX0WUV"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4yPWiRV6FrQTGm6qBX0WUV",
+          "id": "4yPWiRV6FrQTGm6qBX0WUV",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Haywyre Remix",
+          "uri": "spotify:track:4yPWiRV6FrQTGm6qBX0WUV",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2vx3BtBMn8Ed3ygEg1OT2t",
+            "id": "2vx3BtBMn8Ed3ygEg1OT2t",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27385df7b8e4cfe789fffe85364",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0285df7b8e4cfe789fffe85364",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485185df7b8e4cfe789fffe85364",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) [Remixes]",
+            "release_date": "2019-07-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2vx3BtBMn8Ed3ygEg1OT2t",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+                "id": "3JhNCzhSMTxs9WLGJJxWOY",
+                "name": "Macklemore",
+                "type": "artist",
+                "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+                "id": "4UXqAaa6dQYAk18Lv7PEgX",
+                "name": "Fall Out Boy",
+                "type": "artist",
+                "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2vx3BtBMn8Ed3ygEg1OT2t"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/56coS2IZSVdhIlHyzR75mK"
+              },
+              "href": "https://api.spotify.com/v1/artists/56coS2IZSVdhIlHyzR75mK",
+              "id": "56coS2IZSVdhIlHyzR75mK",
+              "name": "Botnek",
+              "type": "artist",
+              "uri": "spotify:artist:56coS2IZSVdhIlHyzR75mK"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 4,
+          "duration_ms": 278095,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4a0iU7VTxdIUrEYG1TSKiM"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4a0iU7VTxdIUrEYG1TSKiM",
+          "id": "4a0iU7VTxdIUrEYG1TSKiM",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Botnek Remix",
+          "uri": "spotify:track:4a0iU7VTxdIUrEYG1TSKiM",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/2vx3BtBMn8Ed3ygEg1OT2t",
+            "id": "2vx3BtBMn8Ed3ygEg1OT2t",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27385df7b8e4cfe789fffe85364",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0285df7b8e4cfe789fffe85364",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485185df7b8e4cfe789fffe85364",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) [Remixes]",
+            "release_date": "2019-07-12",
+            "release_date_precision": "day",
+            "uri": "spotify:album:2vx3BtBMn8Ed3ygEg1OT2t",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+                "id": "3JhNCzhSMTxs9WLGJJxWOY",
+                "name": "Macklemore",
+                "type": "artist",
+                "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+                "id": "4UXqAaa6dQYAk18Lv7PEgX",
+                "name": "Fall Out Boy",
+                "type": "artist",
+                "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/2vx3BtBMn8Ed3ygEg1OT2t"
+            },
+            "total_tracks": 5
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/31ZNfGVEEcI9CyicPVJQni"
+              },
+              "href": "https://api.spotify.com/v1/artists/31ZNfGVEEcI9CyicPVJQni",
+              "id": "31ZNfGVEEcI9CyicPVJQni",
+              "name": "Junior Sanchez",
+              "type": "artist",
+              "uri": "spotify:artist:31ZNfGVEEcI9CyicPVJQni"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 5,
+          "duration_ms": 218880,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/4Seru3XCZsCP1lrbBaljwu"
+          },
+          "href": "https://api.spotify.com/v1/tracks/4Seru3XCZsCP1lrbBaljwu",
+          "id": "4Seru3XCZsCP1lrbBaljwu",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Junior Sanchez Remix",
+          "uri": "spotify:track:4Seru3XCZsCP1lrbBaljwu",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": true,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0xbuJLlb5afBcmCpdOaszR",
+            "id": "0xbuJLlb5afBcmCpdOaszR",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27351528c08d64e44497cb007c0",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0251528c08d64e44497cb007c0",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485151528c08d64e44497cb007c0",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy)",
+            "release_date": "2019-04-25",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0xbuJLlb5afBcmCpdOaszR",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+                },
+                "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+                "id": "3JhNCzhSMTxs9WLGJJxWOY",
+                "name": "Macklemore",
+                "type": "artist",
+                "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+                },
+                "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+                "id": "4UXqAaa6dQYAk18Lv7PEgX",
+                "name": "Fall Out Boy",
+                "type": "artist",
+                "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0xbuJLlb5afBcmCpdOaszR"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/3JhNCzhSMTxs9WLGJJxWOY"
+              },
+              "href": "https://api.spotify.com/v1/artists/3JhNCzhSMTxs9WLGJJxWOY",
+              "id": "3JhNCzhSMTxs9WLGJJxWOY",
+              "name": "Macklemore",
+              "type": "artist",
+              "uri": "spotify:artist:3JhNCzhSMTxs9WLGJJxWOY"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4UXqAaa6dQYAk18Lv7PEgX"
+              },
+              "href": "https://api.spotify.com/v1/artists/4UXqAaa6dQYAk18Lv7PEgX",
+              "id": "4UXqAaa6dQYAk18Lv7PEgX",
+              "name": "Fall Out Boy",
+              "type": "artist",
+              "uri": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 163804,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/7Feaw9WAEREY0DUOSXJLOM"
+          },
+          "href": "https://api.spotify.com/v1/tracks/7Feaw9WAEREY0DUOSXJLOM",
+          "id": "7Feaw9WAEREY0DUOSXJLOM",
+          "name": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy)",
+          "uri": "spotify:track:7Feaw9WAEREY0DUOSXJLOM",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/36EtVEn1SVViW6Pi8rD9n8",
+            "id": "36EtVEn1SVViW6Pi8rD9n8",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27346a81c3b2a02678d5ca6b41c",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0246a81c3b2a02678d5ca6b41c",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485146a81c3b2a02678d5ca6b41c",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Mistaken (feat. Alex Aris)",
+            "release_date": "2019-03-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:36EtVEn1SVViW6Pi8rD9n8",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/36EtVEn1SVViW6Pi8rD9n8"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7J7YzKnvAyEmHCg7LGWW0G"
+              },
+              "href": "https://api.spotify.com/v1/artists/7J7YzKnvAyEmHCg7LGWW0G",
+              "id": "7J7YzKnvAyEmHCg7LGWW0G",
+              "name": "Alex Aris",
+              "type": "artist",
+              "uri": "spotify:artist:7J7YzKnvAyEmHCg7LGWW0G"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 282480,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/18KjYhghq6K3ZmfcewWDp6"
+          },
+          "href": "https://api.spotify.com/v1/tracks/18KjYhghq6K3ZmfcewWDp6",
+          "id": "18KjYhghq6K3ZmfcewWDp6",
+          "name": "Mistaken (feat. Alex Aris)",
+          "uri": "spotify:track:18KjYhghq6K3ZmfcewWDp6",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2026-02-20T21:48:21Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/36EtVEn1SVViW6Pi8rD9n8",
+            "id": "36EtVEn1SVViW6Pi8rD9n8",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27346a81c3b2a02678d5ca6b41c",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0246a81c3b2a02678d5ca6b41c",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485146a81c3b2a02678d5ca6b41c",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Mistaken (feat. Alex Aris)",
+            "release_date": "2019-03-31",
+            "release_date_precision": "day",
+            "uri": "spotify:album:36EtVEn1SVViW6Pi8rD9n8",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+                },
+                "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+                "id": "60d24wfXkVzDSfLS6hyCjZ",
+                "name": "Martin Garrix",
+                "type": "artist",
+                "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+              },
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+                },
+                "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+                "id": "2QMCcKIPHnjQaPPgoEst88",
+                "name": "Matisse & Sadko",
+                "type": "artist",
+                "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/36EtVEn1SVViW6Pi8rD9n8"
+            },
+            "total_tracks": 2
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+              },
+              "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+              "id": "60d24wfXkVzDSfLS6hyCjZ",
+              "name": "Martin Garrix",
+              "type": "artist",
+              "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2QMCcKIPHnjQaPPgoEst88"
+              },
+              "href": "https://api.spotify.com/v1/artists/2QMCcKIPHnjQaPPgoEst88",
+              "id": "2QMCcKIPHnjQaPPgoEst88",
+              "name": "Matisse & Sadko",
+              "type": "artist",
+              "uri": "spotify:artist:2QMCcKIPHnjQaPPgoEst88"
+            },
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/7J7YzKnvAyEmHCg7LGWW0G"
+              },
+              "href": "https://api.spotify.com/v1/artists/7J7YzKnvAyEmHCg7LGWW0G",
+              "id": "7J7YzKnvAyEmHCg7LGWW0G",
+              "name": "Alex Aris",
+              "type": "artist",
+              "uri": "spotify:artist:7J7YzKnvAyEmHCg7LGWW0G"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 2,
+          "duration_ms": 282475,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/1cN45YtJost0rjvbseomXj"
+          },
+          "href": "https://api.spotify.com/v1/tracks/1cN45YtJost0rjvbseomXj",
+          "id": "1cN45YtJost0rjvbseomXj",
+          "name": "Mistaken (feat. Alex Aris) - Club Mix",
+          "uri": "spotify:track:1cN45YtJost0rjvbseomXj",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      }
+    ],
+    "limit": 100,
+    "next": "https://api.spotify.com/v1/playlists/testId/items?offset=100&limit=100",
+    "offset": 0,
+    "previous": null,
+    "total": 231
+  },
+  "type": "playlist",
+  "uri": "spotify:playlist:testId"
+}

--- a/tests/mock_fixtures/mocked_get_playlist_response.json
+++ b/tests/mock_fixtures/mocked_get_playlist_response.json
@@ -1,0 +1,228 @@
+{
+  "collaborative": false,
+  "description": "",
+  "external_urls": {
+    "spotify": "https://open.spotify.com/playlist/fakeId"
+  },
+  "followers": {
+    "href": null,
+    "total": 0
+  },
+  "href": "https://api.spotify.com/v1/playlists/fakeId",
+  "id": "fakeId",
+  "images": [
+    {
+      "height": null,
+      "url": "https://i.scdn.co/image/ab67616d00001e02330890d356d9d8d0ede65b73",
+      "width": null
+    }
+  ],
+  "name": "test playlist",
+  "owner": {
+    "display_name": "testUser",
+    "external_urls": {
+      "spotify": "https://open.spotify.com/user/testUser"
+    },
+    "href": "https://api.spotify.com/v1/users/testUser",
+    "id": "testUser",
+    "type": "user",
+    "uri": "spotify:user:testUser"
+  },
+  "primary_color": null,
+  "public": true,
+  "snapshot_id": "AAAAA/someId",
+  "items": {
+    "href": "https://api.spotify.com/v1/playlists/fakeId/items?offset=0&limit=100",
+    "items": [
+      {
+        "added_at": "2021-05-18T04:15:56Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/1ooVF2ZgjNBCHiIgHCIRh4",
+            "id": "1ooVF2ZgjNBCHiIgHCIRh4",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b273330890d356d9d8d0ede65b73",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02330890d356d9d8d0ede65b73",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00004851330890d356d9d8d0ede65b73",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "BAD BOY",
+            "release_date": "2020-10-30",
+            "release_date_precision": "day",
+            "uri": "spotify:album:1ooVF2ZgjNBCHiIgHCIRh4",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/1QsdzIKkTT5gDFj8GB1cIX"
+                },
+                "href": "https://api.spotify.com/v1/artists/1QsdzIKkTT5gDFj8GB1cIX",
+                "id": "1QsdzIKkTT5gDFj8GB1cIX",
+                "name": "Yseult",
+                "type": "artist",
+                "uri": "spotify:artist:1QsdzIKkTT5gDFj8GB1cIX"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/1ooVF2ZgjNBCHiIgHCIRh4"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/1QsdzIKkTT5gDFj8GB1cIX"
+              },
+              "href": "https://api.spotify.com/v1/artists/1QsdzIKkTT5gDFj8GB1cIX",
+              "id": "1QsdzIKkTT5gDFj8GB1cIX",
+              "name": "Yseult",
+              "type": "artist",
+              "uri": "spotify:artist:1QsdzIKkTT5gDFj8GB1cIX"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 274520,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2gJuY2L6eCxAfIXdXAWtm5"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2gJuY2L6eCxAfIXdXAWtm5",
+          "id": "2gJuY2L6eCxAfIXdXAWtm5",
+          "name": "BAD BOY",
+          "uri": "spotify:track:2gJuY2L6eCxAfIXdXAWtm5",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      },
+      {
+        "added_at": "2021-05-28T04:08:50Z",
+        "added_by": {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/user/testUser"
+          },
+          "href": "https://api.spotify.com/v1/users/testUser",
+          "id": "testUser",
+          "type": "user",
+          "uri": "spotify:user:testUser"
+        },
+        "is_local": false,
+        "primary_color": null,
+        "item": {
+          "is_playable": true,
+          "explicit": false,
+          "type": "track",
+          "episode": false,
+          "track": true,
+          "album": {
+            "is_playable": true,
+            "type": "album",
+            "album_type": "single",
+            "href": "https://api.spotify.com/v1/albums/0FAWfXvd58Rm2VUSZMF8pr",
+            "id": "0FAWfXvd58Rm2VUSZMF8pr",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000b27335d8be841e9f7f777fbca446",
+                "width": 640,
+                "height": 640
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e0235d8be841e9f7f777fbca446",
+                "width": 300,
+                "height": 300
+              },
+              {
+                "url": "https://i.scdn.co/image/ab67616d0000485135d8be841e9f7f777fbca446",
+                "width": 64,
+                "height": 64
+              }
+            ],
+            "name": "Cayendo (Side A - Acoustic)",
+            "release_date": "2020-04-03",
+            "release_date_precision": "day",
+            "uri": "spotify:album:0FAWfXvd58Rm2VUSZMF8pr",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/2h93pZq0e7k5yf4dywlkpM"
+                },
+                "href": "https://api.spotify.com/v1/artists/2h93pZq0e7k5yf4dywlkpM",
+                "id": "2h93pZq0e7k5yf4dywlkpM",
+                "name": "Frank Ocean",
+                "type": "artist",
+                "uri": "spotify:artist:2h93pZq0e7k5yf4dywlkpM"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/0FAWfXvd58Rm2VUSZMF8pr"
+            },
+            "total_tracks": 1
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2h93pZq0e7k5yf4dywlkpM"
+              },
+              "href": "https://api.spotify.com/v1/artists/2h93pZq0e7k5yf4dywlkpM",
+              "id": "2h93pZq0e7k5yf4dywlkpM",
+              "name": "Frank Ocean",
+              "type": "artist",
+              "uri": "spotify:artist:2h93pZq0e7k5yf4dywlkpM"
+            }
+          ],
+          "disc_number": 1,
+          "track_number": 1,
+          "duration_ms": 202200,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/72794Eag03xdy7TO0KNuid"
+          },
+          "href": "https://api.spotify.com/v1/tracks/72794Eag03xdy7TO0KNuid",
+          "id": "72794Eag03xdy7TO0KNuid",
+          "name": "Cayendo (Side A - Acoustic)",
+          "uri": "spotify:track:72794Eag03xdy7TO0KNuid",
+          "is_local": false
+        },
+        "video_thumbnail": {
+          "url": null
+        }
+      }
+    ],
+    "limit": 100,
+    "next": null,
+    "offset": 0,
+    "previous": null,
+    "total": 2
+  },
+  "type": "playlist",
+  "uri": "spotify:playlist:1cZcQPw6waAknbQ7ZKQT63"
+}

--- a/tests/mock_fixtures/mocked_get_user_playlists_response.json
+++ b/tests/mock_fixtures/mocked_get_user_playlists_response.json
@@ -1,0 +1,2384 @@
+{
+  "href": "https://api.spotify.com/v1/me/playlists?offset=0&limit=50",
+  "limit": 50,
+  "next": null,
+  "offset": 0,
+  "previous": null,
+  "total": 34,
+  "items": [
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-1",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0208ef8f213c161fa5b8d5b4f6ab67616d00001e0260cb00c3a3c5cfd33632547fab67616d00001e02beb183cb3868b924ebf5a662ab67616d00001e02f12e9091af7a7626f1bf37db",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0208ef8f213c161fa5b8d5b4f6ab67616d00001e0260cb00c3a3c5cfd33632547fab67616d00001e02beb183cb3868b924ebf5a662ab67616d00001e02f12e9091af7a7626f1bf37db",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0208ef8f213c161fa5b8d5b4f6ab67616d00001e0260cb00c3a3c5cfd33632547fab67616d00001e02beb183cb3868b924ebf5a662ab67616d00001e02f12e9091af7a7626f1bf37db",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist2",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAABo2oOqKL0JhkVNaTmRtVmPYK6wq2",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 1526
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02170ecb722e4e00b3100e36a2ab67616d00001e026e9ed2ad982d703138066c4bab67616d00001e0291b4bc7c88d91a42e0f3a8b7ab67616d00001e02fddfffec51b4580acae727c1",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02170ecb722e4e00b3100e36a2ab67616d00001e026e9ed2ad982d703138066c4bab67616d00001e0291b4bc7c88d91a42e0f3a8b7ab67616d00001e02fddfffec51b4580acae727c1",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02170ecb722e4e00b3100e36a2ab67616d00001e026e9ed2ad982d703138066c4bab67616d00001e0291b4bc7c88d91a42e0f3a8b7ab67616d00001e02fddfffec51b4580acae727c1",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-3",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAFV1iWXumSCYXljOdEkxrkLpwyMKJ",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 20
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e020317618778de80d8d30bfa38ab67616d00001e0209950e9e9655633bc46cdc99ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e028b0e2044b4b20f24908f7122",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e020317618778de80d8d30bfa38ab67616d00001e0209950e9e9655633bc46cdc99ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e028b0e2044b4b20f24908f7122",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e020317618778de80d8d30bfa38ab67616d00001e0209950e9e9655633bc46cdc99ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e028b0e2044b4b20f24908f7122",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-4",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAABWMfeyfRpkVXf9/0zcZDrQD0x+OIw",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 142
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "&lt;&#x2F;3",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da842bfbaf8da7ad820c14ba867c",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-5",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAABRrdqa1ct4N+vKeZp5E9HkIb3fnOx",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 248
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "songs like EOB",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-fa.spotifycdn.com/image/ab67706c0000da84f86459ec94f4b4fcc0b8c09d",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-6",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAUxQ4VGqqclDv+y9oVAXehFW3p19M",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 76
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "jesus christ how many of us are fucked",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da842e46f0d87bfc44ac5bba98ad",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-7",
+      "owner": {
+        "display_name": "not-the-user :]",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAzitRFmtrDRQOD/s5j7n5M0WAkt7z",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 105
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0201e9ff9f8bc29d47a2793cd4ab67616d00001e0216c24c88236c87c148bb4329ab67616d00001e02272fe6fe76e6ebeacdb099a7ab67616d00001e02acafa9f0b34ae64e15bba69a",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0201e9ff9f8bc29d47a2793cd4ab67616d00001e0216c24c88236c87c148bb4329ab67616d00001e02272fe6fe76e6ebeacdb099a7ab67616d00001e02acafa9f0b34ae64e15bba69a",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0201e9ff9f8bc29d47a2793cd4ab67616d00001e0216c24c88236c87c148bb4329ab67616d00001e02272fe6fe76e6ebeacdb099a7ab67616d00001e02acafa9f0b34ae64e15bba69a",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-8",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAds8uorUaVGuE8qIvAL014EfxLUs3",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 104
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e020841e4087e5393a51ec0a70aab67616d00001e0210fa5ddc421f30a8d19775fcab67616d00001e02277620423172f5a151f452e3ab67616d00001e02bf7c317a63c4f128b8823406",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e020841e4087e5393a51ec0a70aab67616d00001e0210fa5ddc421f30a8d19775fcab67616d00001e02277620423172f5a151f452e3ab67616d00001e02bf7c317a63c4f128b8823406",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e020841e4087e5393a51ec0a70aab67616d00001e0210fa5ddc421f30a8d19775fcab67616d00001e02277620423172f5a151f452e3ab67616d00001e02bf7c317a63c4f128b8823406",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-9",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAADNqyS7tjWo/mzXIDWnz78L76Zq6C",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 8
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84c61146742de7b5c0b06a6a6d",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-10",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAZ02XDm7GztTVKujN7AjFCbjKXPOK",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 83
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02023bc3ef3e4e1f0516aa6132ab67616d00001e0216c24c88236c87c148bb4329ab67616d00001e02a043fa84be801dca33dacca1ab67616d00001e02f46e3c72cb61a6d57590fa07",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02023bc3ef3e4e1f0516aa6132ab67616d00001e0216c24c88236c87c148bb4329ab67616d00001e02a043fa84be801dca33dacca1ab67616d00001e02f46e3c72cb61a6d57590fa07",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02023bc3ef3e4e1f0516aa6132ab67616d00001e0216c24c88236c87c148bb4329ab67616d00001e02a043fa84be801dca33dacca1ab67616d00001e02f46e3c72cb61a6d57590fa07",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-11",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAEUKT31aTnUpG+h+M1TAcxYcV0tJh",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 16
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02123a77200078fd34695b7042ab67616d00001e02624927252564ef4625307897ab67616d00001e026b9c9cd2372b640eaeb1a761ab67616d00001e02bf159639cb007db12ea47013",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02123a77200078fd34695b7042ab67616d00001e02624927252564ef4625307897ab67616d00001e026b9c9cd2372b640eaeb1a761ab67616d00001e02bf159639cb007db12ea47013",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02123a77200078fd34695b7042ab67616d00001e02624927252564ef4625307897ab67616d00001e026b9c9cd2372b640eaeb1a761ab67616d00001e02bf159639cb007db12ea47013",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-12",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAId+Z/o10VvQPSdhDqfGNlJczo9Ge",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 27
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "Follow now!",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84eae8f650005924d5de899d4e",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-13",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAN07ZfHPEDClt4Y59LpkhzdC9Hy8g",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 1396
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e026287160ee04a0f09669354d8ab67616d00001e0269c242cfabc71f943cc9adcdab67616d00001e029e3a4115bf31e812e4d42bb2ab67616d00001e02e90832edabae0874acfdec8e",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e026287160ee04a0f09669354d8ab67616d00001e0269c242cfabc71f943cc9adcdab67616d00001e029e3a4115bf31e812e4d42bb2ab67616d00001e02e90832edabae0874acfdec8e",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e026287160ee04a0f09669354d8ab67616d00001e0269c242cfabc71f943cc9adcdab67616d00001e029e3a4115bf31e812e4d42bb2ab67616d00001e02e90832edabae0874acfdec8e",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-14",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAUbXgJvvgGdKI8XWrfgsq6JA0Knva",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 79
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02237088df385325bb2ebbb37bab67616d00001e023a376bd9b9b1f4b2686807dbab67616d00001e029ce3288ac26035edf4351154ab67616d00001e02b993cba8ff7d0a8e9ee18d46",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02237088df385325bb2ebbb37bab67616d00001e023a376bd9b9b1f4b2686807dbab67616d00001e029ce3288ac26035edf4351154ab67616d00001e02b993cba8ff7d0a8e9ee18d46",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02237088df385325bb2ebbb37bab67616d00001e023a376bd9b9b1f4b2686807dbab67616d00001e029ce3288ac26035edf4351154ab67616d00001e02b993cba8ff7d0a8e9ee18d46",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-15",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAJfRpUYJezC2YLQlott3mUYI6Av9M",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 36
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e026fb8b2b3dc9a8dfc3f67362bab67616d00001e02a2b1d3e73c66663c01351bcfab67616d00001e02a75083e6eadc9a3b85688cd8ab67616d00001e02da53f97b4b0f1e14d854f777",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e026fb8b2b3dc9a8dfc3f67362bab67616d00001e02a2b1d3e73c66663c01351bcfab67616d00001e02a75083e6eadc9a3b85688cd8ab67616d00001e02da53f97b4b0f1e14d854f777",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e026fb8b2b3dc9a8dfc3f67362bab67616d00001e02a2b1d3e73c66663c01351bcfab67616d00001e02a75083e6eadc9a3b85688cd8ab67616d00001e02da53f97b4b0f1e14d854f777",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-16",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAGCG2+QfhffFqlnHfbWG2DQT1gGCX",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 17
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02566acaba72c5509e3887c4b0ab67616d00001e025e1ce5aa689604f39fb5d303ab67616d00001e0290b88187a9831d91f2438927ab67616d00001e02de5a8550905395c2d8f7a410",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02566acaba72c5509e3887c4b0ab67616d00001e025e1ce5aa689604f39fb5d303ab67616d00001e0290b88187a9831d91f2438927ab67616d00001e02de5a8550905395c2d8f7a410",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02566acaba72c5509e3887c4b0ab67616d00001e025e1ce5aa689604f39fb5d303ab67616d00001e0290b88187a9831d91f2438927ab67616d00001e02de5a8550905395c2d8f7a410",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-17",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAF/CoToP5+bWs0eXIPjy75eO7CJcq",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 21
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e0243e677beedf6ae3d340328f0ab67616d00001e025699ca5a7af862fa5a522016ab67616d00001e02aacb4d483af87300fa8333b4",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e0243e677beedf6ae3d340328f0ab67616d00001e025699ca5a7af862fa5a522016ab67616d00001e02aacb4d483af87300fa8333b4",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e0243e677beedf6ae3d340328f0ab67616d00001e025699ca5a7af862fa5a522016ab67616d00001e02aacb4d483af87300fa8333b4",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-18",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAYna/7tD06RsfXZ3bHPBdb0fQr9Vw",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 87
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "Your goto playlist for relaxing, working, studying, driving, &amp; bawling your f*cking eyes out 😭 (Updated: 9&#x2F;19&#x2F;24)",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-fa.spotifycdn.com/image/ab67706c0000da841569a5667d80afd987582179",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-19",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAsCL8flINEEhD8uOMCxl2FHvJ5lMbN",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 53
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02123a77200078fd34695b7042ab67616d00001e0252842eb76a050aa8daec1251ab67616d00001e02624927252564ef4625307897ab67616d00001e02efd6f1e1a3cd533cd854fe04",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02123a77200078fd34695b7042ab67616d00001e0252842eb76a050aa8daec1251ab67616d00001e02624927252564ef4625307897ab67616d00001e02efd6f1e1a3cd533cd854fe04",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02123a77200078fd34695b7042ab67616d00001e0252842eb76a050aa8daec1251ab67616d00001e02624927252564ef4625307897ab67616d00001e02efd6f1e1a3cd533cd854fe04",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-20",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAABQDIwfpKX8hFn4BIYZeGEVQy7fiJ3",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 236
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "You are so welcome",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84c78ac5332d77ee029bae18df",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-21",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAABIz2ZeO4KNldMTw3od1Nh3QDY1cHI",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 153
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "do i love u or do i love being in love with you?",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84e39990e4c17413c954a072f5",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-22",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAALhoqSA/3F5UjIsTBi6mdpSpRdLfS",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 31
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "Selection of the best relaxing lofi hip hop beats for the perfect chill session - best lofi cover playlist - best lofi songs - lofi hip hop playlist - best study music - lofi remix playlist - relaxing beats playlist - chill beats playlist - lofi covers playlist - lofi beats - lofi fruits music",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84bc777cc650ddc2876875dca5",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-23",
+      "owner": {
+        "display_name": "not-the-user",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/not-the-user"
+        },
+        "href": "https://api.spotify.com/v1/users/not-the-user",
+        "id": "not-the-user",
+        "type": "user",
+        "uri": "spotify:user:not-the-user"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAevdQj1qUfAcOAvwmCbZLa1AhZTOMc",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 250
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0209950e9e9655633bc46cdc99ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e026a6bb3ef49451f7ec734bf38ab67616d00001e02ef4ad54571b3e9bc1bd0b6a8",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0209950e9e9655633bc46cdc99ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e026a6bb3ef49451f7ec734bf38ab67616d00001e02ef4ad54571b3e9bc1bd0b6a8",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0209950e9e9655633bc46cdc99ab67616d00001e0233a839e8b2cf1512f3badabbab67616d00001e026a6bb3ef49451f7ec734bf38ab67616d00001e02ef4ad54571b3e9bc1bd0b6a8",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-24",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAn6J8BKxYjGjpieOMDyGI+owlBkfn",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 142
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02132018693b0dc6095d18cf96ab67616d00001e02529c6fa82d23f65076c1579bab67616d00001e026a6bb3ef49451f7ec734bf38ab67616d00001e02f0c28fd474b79a9e5fb325b6",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02132018693b0dc6095d18cf96ab67616d00001e02529c6fa82d23f65076c1579bab67616d00001e026a6bb3ef49451f7ec734bf38ab67616d00001e02f0c28fd474b79a9e5fb325b6",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02132018693b0dc6095d18cf96ab67616d00001e02529c6fa82d23f65076c1579bab67616d00001e026a6bb3ef49451f7ec734bf38ab67616d00001e02f0c28fd474b79a9e5fb325b6",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-25",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAJjlQWDzmLoZkDkbeBoMhkoayhm9N",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 26
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e021d24f8fa55739bdf2fecfd24ab67616d00001e024802f7bccb36622a3b5e3b67ab67616d00001e026f82ea04d1dbc1aa57ae83efab67616d00001e02f672cfe50a513713ea7cdc85",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e021d24f8fa55739bdf2fecfd24ab67616d00001e024802f7bccb36622a3b5e3b67ab67616d00001e026f82ea04d1dbc1aa57ae83efab67616d00001e02f672cfe50a513713ea7cdc85",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e021d24f8fa55739bdf2fecfd24ab67616d00001e024802f7bccb36622a3b5e3b67ab67616d00001e026f82ea04d1dbc1aa57ae83efab67616d00001e02f672cfe50a513713ea7cdc85",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-26",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAF6Rh3DKZFuaplWMVj/ly02nhtQO1",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 21
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e02146ee402c8243cf8db8630e6ab67616d00001e022abcc266597eb46f897a8666ab67616d00001e024cc52cd7a712842234e4fce2ab67616d00001e02d841ad4d4aa791514d7e9758",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e02146ee402c8243cf8db8630e6ab67616d00001e022abcc266597eb46f897a8666ab67616d00001e024cc52cd7a712842234e4fce2ab67616d00001e02d841ad4d4aa791514d7e9758",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e02146ee402c8243cf8db8630e6ab67616d00001e022abcc266597eb46f897a8666ab67616d00001e024cc52cd7a712842234e4fce2ab67616d00001e02d841ad4d4aa791514d7e9758",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-27",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAANU1yzNoGYG1V6DUhTJU3gNfl87nw",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 48
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e024408ede3829b9cbcaea9f3b8ab67616d00001e026fb8b2b3dc9a8dfc3f67362bab67616d00001e028eb0afbe6876a436ca5f233dab67616d00001e02a75083e6eadc9a3b85688cd8",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e024408ede3829b9cbcaea9f3b8ab67616d00001e026fb8b2b3dc9a8dfc3f67362bab67616d00001e028eb0afbe6876a436ca5f233dab67616d00001e02a75083e6eadc9a3b85688cd8",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e024408ede3829b9cbcaea9f3b8ab67616d00001e026fb8b2b3dc9a8dfc3f67362bab67616d00001e028eb0afbe6876a436ca5f233dab67616d00001e02a75083e6eadc9a3b85688cd8",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-28",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAGhximJC6A2Xj4OtGzW8nf7naqHmC",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 25
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0218342a202903877c0757f2d7ab67616d00001e02541ff97d162f41603b4c7942ab67616d00001e02ab72ee424580b3816e71fe97ab67616d00001e02dff036770a72383b8d747bd9",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0218342a202903877c0757f2d7ab67616d00001e02541ff97d162f41603b4c7942ab67616d00001e02ab72ee424580b3816e71fe97ab67616d00001e02dff036770a72383b8d747bd9",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0218342a202903877c0757f2d7ab67616d00001e02541ff97d162f41603b4c7942ab67616d00001e02ab72ee424580b3816e71fe97ab67616d00001e02dff036770a72383b8d747bd9",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-29",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAADfQ6F1hok6AL57W2GTQC/JB7GwNE",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 12
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0218a4a215052e9f396864bd73ab67616d00001e0218d0ed4f969b376893f9a38fab67616d00001e024ee9dc60013d5648d0f23bccab67616d00001e0268bc19df3564f7e8c828cbe0",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0218a4a215052e9f396864bd73ab67616d00001e0218d0ed4f969b376893f9a38fab67616d00001e024ee9dc60013d5648d0f23bccab67616d00001e0268bc19df3564f7e8c828cbe0",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0218a4a215052e9f396864bd73ab67616d00001e0218d0ed4f969b376893f9a38fab67616d00001e024ee9dc60013d5648d0f23bccab67616d00001e0268bc19df3564f7e8c828cbe0",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-30",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAABx0xVDYy0834bzSKHXGNrbVgzefi",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 6
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://i.scdn.co/image/ab67616d00001e02ef4ad54571b3e9bc1bd0b6a8",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-31",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAABZP5FjFkagKeBrNWl32SzHueyLNl",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 3
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e021c29562d6e8c1f55bb1311d5ab67616d00001e024f0fd9dad63977146e685700ab67616d00001e027aa8783ad8def37cc548a9cfab67616d00001e028b52c6b9bc4e43d873869699",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e021c29562d6e8c1f55bb1311d5ab67616d00001e024f0fd9dad63977146e685700ab67616d00001e027aa8783ad8def37cc548a9cfab67616d00001e028b52c6b9bc4e43d873869699",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e021c29562d6e8c1f55bb1311d5ab67616d00001e024f0fd9dad63977146e685700ab67616d00001e027aa8783ad8def37cc548a9cfab67616d00001e028b52c6b9bc4e43d873869699",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-32",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAAGNYoeyEQ6iofg0vd45O/uo5tYYUe",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 23
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e0226f7f19c7f0381e56156c94aab67616d00001e02346d77e155d854735410ed18ab67616d00001e02f6b55ca93bd33211227b502bab67616d00001e02f9685817281327d5fecb244e",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e0226f7f19c7f0381e56156c94aab67616d00001e02346d77e155d854735410ed18ab67616d00001e02f6b55ca93bd33211227b502bab67616d00001e02f9685817281327d5fecb244e",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e0226f7f19c7f0381e56156c94aab67616d00001e02346d77e155d854735410ed18ab67616d00001e02f6b55ca93bd33211227b502bab67616d00001e02f9685817281327d5fecb244e",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-33",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": false,
+      "snapshot_id": "AAAACRaSJfNxZQ64NYaovclfWQfBjfD7",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 4
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+    {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": null,
+          "url": "https://i.scdn.co/image/ab67616d00001e02330890d356d9d8d0ede65b73",
+          "width": null
+        }
+      ],
+      "name": "test-playlist-34",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAA/WY5yrc12DPQe3CYO7cDR9r3J2j",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 2
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-35",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-36",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-37",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-38",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-39",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-40",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-41",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-42",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-43",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-44",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-45",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-46",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-47",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-48",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-49",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-50",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-51",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-52",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-53",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    },
+        {
+      "collaborative": false,
+      "description": "",
+      "external_urls": {
+        "spotify": "https://open.spotify.com/playlist/fakeId"
+      },
+      "href": "https://api.spotify.com/v1/playlists/fakeId",
+      "id": "fakeId",
+      "images": [
+        {
+          "height": 640,
+          "url": "https://mosaic.scdn.co/640/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 640
+        },
+        {
+          "height": 300,
+          "url": "https://mosaic.scdn.co/300/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 300
+        },
+        {
+          "height": 60,
+          "url": "https://mosaic.scdn.co/60/ab67616d00001e025463877b909d6eaf35e27d96ab67616d00001e02654151030adcbda019dcba22ab67616d00001e0270969b566dd6d6646a6b42cbab67616d00001e02ebcfc84442b172f6291a3b74",
+          "width": 60
+        }
+      ],
+      "name": "test-playlist-54",
+      "owner": {
+        "display_name": "testUser",
+        "external_urls": {
+          "spotify": "https://open.spotify.com/user/testUser"
+        },
+        "href": "https://api.spotify.com/v1/users/testUser",
+        "id": "testUser",
+        "type": "user",
+        "uri": "spotify:user:testUser"
+      },
+      "primary_color": null,
+      "public": true,
+      "snapshot_id": "AAAAAxQ8HvLFvgHqqqLw2TxjwcVDVQsL",
+      "items": {
+        "href": "https://api.spotify.com/v1/playlist/fakeId/items",
+        "total": 231
+      },
+      "type": "playlist",
+      "uri": "spotify:playlist:fakeId"
+    }
+  ]
+}

--- a/tests/mock_fixtures/mocked_ytm_oauth.json
+++ b/tests/mock_fixtures/mocked_ytm_oauth.json
@@ -1,0 +1,8 @@
+{
+ "scope": "https://www.googleapis.com/auth/youtube",
+ "token_type": "Bearer",
+ "access_token": "fakeToken",
+ "refresh_token": "fakeRefreshToken",
+ "expires_at": 1770943011,
+ "expires_in": 3599
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,11 +14,30 @@ from spotify_to_ytmusic.settings import CACHE_DIR, DEFAULT_PATH, EXAMPLE_PATH, S
 TEST_PLAYLIST = "https://open.spotify.com/playlist/4UzyZJfSQ4584FaWGwepfL"
 TEST_SONG = "https://open.spotify.com/track/7bnczC5ATlZaZX0MHjX7KU?si=5a07bffaf6324717"
 
-
 class TestCli:
     @pytest.fixture(autouse=True)
     def fixture_settings(self):
         Settings()
+    
+    @pytest.fixture
+    def oauth_renew_credentials_json(self):
+        mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_ytm_oauth.json"
+        with mocked_playlist_response_path.open() as f:
+            return json.load(f)
+    
+    @pytest.fixture
+    def spotify_playlist_json(self):
+        mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_get_playlist_response.json"
+        with mocked_playlist_response_path.open() as f:
+            return json.load(f)
+
+    @pytest.fixture(scope="function")
+    def mock_spotify_api_playlist(self, spotify_playlist_json):
+        with mock.patch("spotify_to_ytmusic.spotify.spotipy.Spotify") as MockSpotipy:
+            mock_client = MockSpotipy.return_value
+            mock_client.playlist.return_value = spotify_playlist_json
+
+            yield mock_client
 
     def test_get_args(self):
         args = get_args(["all", "user"])
@@ -41,10 +60,7 @@ class TestCli:
         ):
             main()
 
-    def test_create(self):
-        with mock.patch("sys.argv", ["", "all", "sigmatics"]):
-            main()
-
+    def test_create(self, mock_spotify_api_playlist):
         with mock.patch(
             "sys.argv",
             [
@@ -92,7 +108,7 @@ class TestCli:
             main()
         assert cache_file.exists(), "Cache file was not created."
 
-    def test_setup(self):
+    def test_setup(self, oauth_renew_credentials_json):
         tmp_path = DEFAULT_PATH.with_suffix(".tmp")
         settings = Settings()
         with (
@@ -111,7 +127,7 @@ class TestCli:
             ),
             mock.patch(
                 "ytmusicapi.auth.oauth.credentials.OAuthCredentials.token_from_code",
-                return_value=json.loads(settings["youtube"]["headers"]),
+                return_value=oauth_renew_credentials_json,
             ),
             mock.patch.object(setup, "DEFAULT_PATH", tmp_path),
             mock.patch("spotify_to_ytmusic.setup.has_browser", return_value=False),
@@ -135,3 +151,12 @@ class TestCli:
             main()
             assert tmp_path.is_file()
             tmp_path.unlink()
+
+    def test_all_command_prints_deprecation_message(self):
+        fake_stdout = StringIO()
+        with mock.patch("sys.stdout", new=fake_stdout):
+            with mock.patch("sys.argv", ["", "all", "user"]):
+                main()
+
+        output = fake_stdout.getvalue()
+        assert "DEPRECATED" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,12 +151,3 @@ class TestCli:
             main()
             assert tmp_path.is_file()
             tmp_path.unlink()
-
-    def test_all_command_prints_deprecation_message(self):
-        fake_stdout = StringIO()
-        with mock.patch("sys.stdout", new=fake_stdout):
-            with mock.patch("sys.argv", ["", "all", "user"]):
-                main()
-
-        output = fake_stdout.getvalue()
-        assert "DEPRECATED" in output

--- a/tests/test_spotipy.py
+++ b/tests/test_spotipy.py
@@ -1,20 +1,50 @@
+import json
 import pytest
+from pathlib import Path
+from unittest import mock
+
 
 from spotify_to_ytmusic.spotify import Spotify
 
 
 class TestSpotify:
     @pytest.fixture(autouse=True)
-    def fixture_spotify(self):
+    def fixture_spotify(self, mock_spotify_api):
         self.spotify = Spotify()
+    
+    @pytest.fixture
+    def spotify_playlist_json(self):
+        mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_get_large_playlist_response.json"
+        with mocked_playlist_response_path.open() as f:
+            return json.load(f)
 
-    def test_getSpotifyPlaylist(self):
+    @pytest.fixture
+    def spotify_playlist_items_page_2_json(self):
+        mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_get_large_playlist_items_response_page_2.json"
+        with mocked_playlist_response_path.open() as f:
+            return json.load(f)
+
+    @pytest.fixture
+    def spotify_playlist_items_page_3_json(self):
+        mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_get_large_playlist_items_response_page_3.json"
+        with mocked_playlist_response_path.open() as f:
+            return json.load(f)
+
+    @pytest.fixture(autouse=True)
+    def mock_spotify_api(self, spotify_playlist_json, spotify_playlist_items_page_2_json, spotify_playlist_items_page_3_json):
+        with mock.patch("spotify_to_ytmusic.spotify.spotipy.Spotify") as MockSpotipy:
+            self.mock_client = MockSpotipy.return_value
+
+            self.mock_client.playlist.return_value = spotify_playlist_json
+            self.mock_client.playlist_items.side_effect = [spotify_playlist_items_page_2_json, spotify_playlist_items_page_3_json]
+
+            yield self.mock_client
+
+    def test_getSpotifyPlaylist(self, mock_spotify_api):
+        with open("/home/easotelo1/dev/python/git/spotify_to_ytmusic/tests/mock_fixtures/mocked_get_large_playlist_response.json") as f:
+            data = json.load(f)
         data = self.spotify.getSpotifyPlaylist(
             "https://open.spotify.com/playlist/03ICMYsVsC4I2SZnERcQJb"
         )
         assert len(data) == 3
         assert len(data["tracks"]) > 190
-
-    def test_getUserPlaylists(self):
-        playlists = self.spotify.getUserPlaylists("spinninrecordsofficial")
-        assert len(playlists) > 40

--- a/tests/test_spotipy.py
+++ b/tests/test_spotipy.py
@@ -19,6 +19,12 @@ class TestSpotify:
             return json.load(f)
 
     @pytest.fixture
+    def spotify_all_playlists_json(self):
+        mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_get_user_playlists_response.json"
+        with mocked_playlist_response_path.open() as f:
+            return json.load(f)
+
+    @pytest.fixture
     def spotify_playlist_items_page_2_json(self):
         mocked_playlist_response_path = Path(__file__).parent / "mock_fixtures" / "mocked_get_large_playlist_items_response_page_2.json"
         with mocked_playlist_response_path.open() as f:
@@ -31,11 +37,12 @@ class TestSpotify:
             return json.load(f)
 
     @pytest.fixture(autouse=True)
-    def mock_spotify_api(self, spotify_playlist_json, spotify_playlist_items_page_2_json, spotify_playlist_items_page_3_json):
+    def mock_spotify_api(self, spotify_playlist_json, spotify_all_playlists_json, spotify_playlist_items_page_2_json, spotify_playlist_items_page_3_json):
         with mock.patch("spotify_to_ytmusic.spotify.spotipy.Spotify") as MockSpotipy:
             self.mock_client = MockSpotipy.return_value
 
             self.mock_client.playlist.return_value = spotify_playlist_json
+            self.mock_client.user_playlists.return_value = spotify_all_playlists_json
             self.mock_client.playlist_items.side_effect = [spotify_playlist_items_page_2_json, spotify_playlist_items_page_3_json]
 
             yield self.mock_client
@@ -48,3 +55,7 @@ class TestSpotify:
         )
         assert len(data) == 3
         assert len(data["tracks"]) > 190
+    
+    def test_getUserPlaylists(self):
+        playlists = self.spotify.getUserPlaylists("testUser")
+        assert len(playlists) > 40


### PR DESCRIPTION
- Copying public playlists to youtube is no longer allowed with the recent api changes. Only USER playlists is possible
- - Updated tests to account for this 
- getPlaylist(playlistId) response has changed. Updated keys to reflect response changes
- - getLikedPlaylist() and getPlaylist() also have differing responses now. Updated build_results to account for this
- Added mocked test data to update unit tests that were now failing due to spotify api changes
- Updated all tests to reflect changes
- Updated readme 